### PR TITLE
Restore compression to base template with CssAbsoluteFilter

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -191,7 +191,7 @@ WEBPACK_LOADER = {
 }
 
 COMPRESS_CSS_FILTERS = [
-    'compressor.filters.cssmin.CSSMinFilter'
+    'compressor.filters.css_default.CssAbsoluteFilter',
 ]
 
 THUMBNAIL_PRESERVE_FORMAT = True

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -26,7 +26,9 @@
     {% block feeds %}{% endblock %}
 
     {# Project #}
-    <link rel="stylesheet" href="{% static 'build/css/app.css' %}">
+    {% compress css %}
+      <link rel="stylesheet" href="{% static 'build/css/app.css' %}">
+    {% endcompress %}
 
     {% block css %}{% endblock %}
   </head>


### PR DESCRIPTION
We stopped using the compressor because it broke calc queries, but CssAbsoluteFilter does not; it merely normalises URLs. This is a no-op in our case, so it effectively becomes a concatenator, which has two advantages:

1) As CSS in the frontend build is split out into two parts (stuff from CSS and stuff from Vue components), this means one HTTP request to load CSS rather than two.

2) A new filename is generated whenever the CSS changes, which means site updates do not require a subsequent cache clear.
