### PR TITLE
Normalise database names: server.json should use cookiecutter.package_name

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/server.json
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/server.json
@@ -1,7 +1,7 @@
 {
     "local": {
         "database": {
-            "name": "{{cookiecutter.repo_name}}"
+            "name": "{{cookiecutter.package_name}}"
         }
     },
     "remotes": {
@@ -12,8 +12,8 @@
                 "initial_user": "root"
             },
             "database": {
-                "name": "{{cookiecutter.repo_name}}",
-                "user": "{{cookiecutter.repo_name}}",
+                "name": "{{cookiecutter.package_name}}",
+                "user": "{{cookiecutter.package_name}}",
                 "password": ""
             },
             "is_aws": false


### PR DESCRIPTION
Currently, the `server.json` in the template uses `cookiecutter.repo_name` rather than `cookiecutter.package_name`. This will lead to problems when `repo_name` and `package_name` differ (for example, if there is a dash in `repo_name`).

This fixes server.json to use `package_name`.
