### PR TITLE
Use project_name for media/static paths on server

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -53,7 +53,7 @@ DATABASES = {
 
 # Absolute path to the directory where all uploaded media files are stored.
 
-MEDIA_ROOT = "/var/www/{{cookiecutter.repo_name}}_media"
+MEDIA_ROOT = "/var/www/{{cookiecutter.package_name}}_media"
 
 MEDIA_URL = "/media/"
 
@@ -62,11 +62,11 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 
 # Absolute path to the directory where static files will be collected.
 
-STATIC_ROOT = "/var/www/{{cookiecutter.repo_name}}_static"
+STATIC_ROOT = "/var/www/{{cookiecutter.package_name}}_static"
 
 STATIC_URL = "/static/"
 
-NODE_MODULES_ROOT = "/var/www/{{cookiecutter.repo_name}}_static"
+NODE_MODULES_ROOT = "/var/www/{{cookiecutter.package_name}}_static"
 
 NODE_MODULES_URL = "/static/"
 


### PR DESCRIPTION
When repo_name is not the same as package_name, this causes the path to which `collectstatic` will save files and the paths which `manage.py deploy` expects diverge.

This normalises them by always using `package_name` as the base name for all three directories that server-management creates in /var/www/.
