### PR TITLE
Remove Python Social Auth from Suit menu.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -36,7 +36,8 @@ ALLOWED_HOSTS = [
 ]
 
 SUIT_CONFIG = {
-    'ADMIN_NAME': SITE_NAME
+    'ADMIN_NAME': SITE_NAME,
+    'MENU_EXCLUDE': ['default'],
 }
 
 # Database settings.


### PR DESCRIPTION
It is extremely rare that it will be used (debugging Social Auth is the only scenario I can imagine), and so it's just clutter on the main menu.
