### PR TITLE
Use cookiecutter.package_name rather than cookiecutter.project_name in browserSync.js.

### DIFF
--- a/{{cookiecutter.repo_name}}/gulpfile.js/tasks/browserSync.js
+++ b/{{cookiecutter.repo_name}}/gulpfile.js/tasks/browserSync.js
@@ -5,7 +5,7 @@ var gulp        = require('gulp')
 var browserSyncTask = function() {
   browserSync.init(config.tasks.browserSync)
 
-  gulp.watch(['{{cookiecutter.project_name}}/apps/**/templates/**/*.html', '{{cookiecutter.project_name}}/templates/**/*.html'], browserSync.reload)
+  gulp.watch(['{{cookiecutter.package_name}}/apps/**/templates/**/*.html', '{{cookiecutter.package_name}}/templates/**/*.html'], browserSync.reload)
 }
 gulp.task('browserSync', browserSyncTask)
 module.exports = browserSyncTask


### PR DESCRIPTION
Fixes issue #32.
