### PR TITLE
Fix frontend build

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -3,7 +3,7 @@
   "main": "gulpfile.js",
   "devDependencies": {
     "autoprefixer": "^6.3.6",
-    "babel-core": "6.7.2",
+    "babel-core": "6.8.0",
     "babel-eslint": "^4.1.5",
     "babel-loader": "6.2.4",
     "babel-plugin-transform-runtime": "^6.4.0",
@@ -60,6 +60,7 @@
     "postcss-nested": "^1.0.0",
     "postcss-property-lookup": "^1.2.1",
     "postcss-pxtorem": "^3.3.1",
+    "postcss-reporter": "1.0.0",
     "postcss-round-subpixels": "^1.2.0",
     "postcss-sassy-mixins": "^2.0.0",
     "postcss-will-change": "^1.0.0",


### PR DESCRIPTION
A higher version of babel-core was required than the one that was in package.json, and postcss-reporter was in the CSS gulp task but not in the package.json.
