### PR TITLE
Add favicons to frontend build.

### DIFF
--- a/{{cookiecutter.repo_name}}/gulpfile.js/config.json
+++ b/{{cookiecutter.repo_name}}/gulpfile.js/config.json
@@ -46,7 +46,7 @@
     "images": {
       "src": "img",
       "dest": "img",
-      "extensions": ["jpg", "png", "svg", "gif"]
+      "extensions": ["jpg", "png", "svg", "gif", "ico"]
     },
 
     "fonts": {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_favicons.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_favicons.html
@@ -1,21 +1,21 @@
 {% load static %}
 
-<link rel="shortcut icon" href="{% static 'favicons/favicon.ico'%}" type="image/x-icon"/>
-<link rel="apple-touch-icon" sizes="57x57" href="{% static 'favicons/apple-touch-icon-57x57.png' %}">
-<link rel="apple-touch-icon" sizes="60x60" href="{% static 'favicons/apple-touch-icon-60x60.png' %}">
-<link rel="apple-touch-icon" sizes="72x72" href="{% static 'favicons/apple-touch-icon-72x72.png' %}">
-<link rel="apple-touch-icon" sizes="76x76" href="{% static 'favicons/apple-touch-icon-76x76.png' %}">
-<link rel="apple-touch-icon" sizes="114x114" href="{% static 'favicons/apple-touch-icon-114x114.png' %}">
-<link rel="apple-touch-icon" sizes="120x120" href="{% static 'favicons/apple-touch-icon-120x120.png' %}">
-<link rel="apple-touch-icon" sizes="144x144" href="{% static 'favicons/apple-touch-icon-144x144.png' %}">
-<link rel="apple-touch-icon" sizes="152x152" href="{% static 'favicons/apple-touch-icon-152x152.png' %}">
-<link rel="apple-touch-icon" sizes="180x180" href="{% static 'favicons/apple-touch-icon-180x180.png' %}">
-<link rel="icon" type="image/png" href="{% static 'favicons/favicon-16x16.png' %}" sizes="16x16">
-<link rel="icon" type="image/png" href="{% static 'favicons/favicon-32x32.png' %}" sizes="32x32">
-<link rel="icon" type="image/png" href="{% static 'favicons/favicon-96x96.png' %}" sizes="96x96">
-<link rel="icon" type="image/png" href="{% static 'favicons/android-chrome-192x192.png' %}" sizes="192x192">
+<link rel="shortcut icon" href="{% static 'build/img/favicons/favicon.ico'%}" type="image/x-icon"/>
+<link rel="apple-touch-icon" sizes="57x57" href="{% static 'build/img/favicons/apple-touch-icon-57x57.png' %}">
+<link rel="apple-touch-icon" sizes="60x60" href="{% static 'build/img/favicons/apple-touch-icon-60x60.png' %}">
+<link rel="apple-touch-icon" sizes="72x72" href="{% static 'build/img/favicons/apple-touch-icon-72x72.png' %}">
+<link rel="apple-touch-icon" sizes="76x76" href="{% static 'build/img/favicons/apple-touch-icon-76x76.png' %}">
+<link rel="apple-touch-icon" sizes="114x114" href="{% static 'build/img/favicons/apple-touch-icon-114x114.png' %}">
+<link rel="apple-touch-icon" sizes="120x120" href="{% static 'build/img/favicons/apple-touch-icon-120x120.png' %}">
+<link rel="apple-touch-icon" sizes="144x144" href="{% static 'build/img/favicons/apple-touch-icon-144x144.png' %}">
+<link rel="apple-touch-icon" sizes="152x152" href="{% static 'build/img/favicons/apple-touch-icon-152x152.png' %}">
+<link rel="apple-touch-icon" sizes="180x180" href="{% static 'build/img/favicons/apple-touch-icon-180x180.png' %}">
+<link rel="icon" type="image/png" href="{% static 'build/img/favicons/favicon-16x16.png' %}" sizes="16x16">
+<link rel="icon" type="image/png" href="{% static 'build/img/favicons/favicon-32x32.png' %}" sizes="32x32">
+<link rel="icon" type="image/png" href="{% static 'build/img/favicons/favicon-96x96.png' %}" sizes="96x96">
+<link rel="icon" type="image/png" href="{% static 'build/img/favicons/android-chrome-192x192.png' %}" sizes="192x192">
 
-<meta name="msapplication-square70x70logo" content="{% static 'favicons/smalltile.png' %}"/>
-<meta name="msapplication-square150x150logo" content="{% static 'favicons/mediumtile.png' %}"/>
-<meta name="msapplication-wide310x150logo" content="{% static 'favicons/widetile.png' %}"/>
-<meta name="msapplication-square310x310logo" content="{% static 'favicons/largetile.png' %}"/>
+<meta name="msapplication-square70x70logo" content="{% static 'build/img/favicons/smalltile.png' %}"/>
+<meta name="msapplication-square150x150logo" content="{% static 'build/img/favicons/mediumtile.png' %}"/>
+<meta name="msapplication-wide310x150logo" content="{% static 'build/img/favicons/widetile.png' %}"/>
+<meta name="msapplication-square310x310logo" content="{% static 'build/img/favicons/largetile.png' %}"/>


### PR DESCRIPTION
Right now the favicons include in the header is relying on favicons living in a `favicons` folder in the root static directory. As nothing is copied here by the build system (and the `static` directory is `.gitignore`'d) it means you effectively can't keep favicons in your repo.

This corrects this by 1) assuming favicons will live in `assets/img/favicons` and will be deployed to  `STATIC/build/img/favicons` 2) adding `.ico` files to the `images` gulp task so that they are copied with all the other image file types.
