### PR TITLE
Add 'registration' to list of excluded template paths for jinja2.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -252,7 +252,7 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "match_extension": ".html",
-            "match_regex": r"^(?!admin/|reversion/).*",
+            "match_regex": r"^(?!admin/|reversion/|registration/).*",
             "app_dirname": "templates",
             "newstyle_gettext": True,
             "extensions": DEFAULT_EXTENSIONS + [


### PR DESCRIPTION
This fixes an exception being caused on admin logout.