### PR TITLE
Add ALLOWED_HOSTS to local settings to fix Django 1.10.3 and 1.8.16

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
@@ -24,6 +24,11 @@ NODE_MODULES_ROOT = os.path.expanduser(os.path.join("~/Workspace/{{cookiecutter.
 
 SITE_DOMAIN = "localhost:8000"
 
+ALLOWED_HOSTS = ALLOWED_HOSTS + [
+    "127.0.0.1",
+    "localhost",
+]
+
 PREPEND_WWW = False
 
 # Optional separate database settings

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
@@ -24,10 +24,13 @@ NODE_MODULES_ROOT = os.path.expanduser(os.path.join("~/Workspace/{{cookiecutter.
 
 SITE_DOMAIN = "localhost:8000"
 
-ALLOWED_HOSTS = ALLOWED_HOSTS + [
-    "0.0.0.0",
+ALLOWED_HOSTS = [
+    # Django's defaults.
     "127.0.0.1",
     "localhost",
+    "::1",
+    # For compatibility with Browsersync.
+    "0.0.0.0",
 ]
 
 PREPEND_WWW = False

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
@@ -25,6 +25,7 @@ NODE_MODULES_ROOT = os.path.expanduser(os.path.join("~/Workspace/{{cookiecutter.
 SITE_DOMAIN = "localhost:8000"
 
 ALLOWED_HOSTS = ALLOWED_HOSTS + [
+    "0.0.0.0",
     "127.0.0.1",
     "localhost",
 ]


### PR DESCRIPTION
ALLOWED_HOSTS is now required to be set even with DEBUG on:

https://www.djangoproject.com/weblog/2016/nov/01/security-releases/

This adds 'localhost' and '127.0.0.1' as sensible defaults for local development.