### PR TITLE
Add JS to open all external links in a new window. Ref #54.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/external-links/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/external-links/index.js
@@ -41,12 +41,12 @@ export default function () {
         // Add noopener and 'noreferrer' to work around this:
         // https://dev.to/ben/the-targetblank-vulnerability-by-example
         let rel = link.getAttribute('rel')
-        
+
         if (!rel) {
           // will be null if it is not set
           rel = ''
         }
-        
+
         link.setAttribute('rel', `${rel} noopener noreferrer`)
       }
     }
@@ -56,10 +56,10 @@ export default function () {
       if (href.indexOf(prefix) === 0) {
         link.addEventListener('click', (event) => {
           event.preventDefault()
-          
+
           window.open(href, '_blank', 'width=600,height=300,menubar=0,toolbar=0,status=0')
         })
-        
+
         break
       }
     }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/external-links/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/external-links/index.js
@@ -1,0 +1,63 @@
+/*
+External links (defined as all links pointing to a domain that is not the
+same as the one from which the current document is being served)
+will have their 'target' attribute set to '_blank'.
+
+Social media sharing links will show in a popup.
+*/
+export default function () {
+  const links = [].slice.call(document.getElementsByTagName('a'))
+
+  // If the link starts with any of these things, we'll open a 600x300 popup
+  // window for them.
+  const usePopupPrefixes = [
+    'https://twitter.com/intent/tweet?',
+    'https://www.facebook.com/sharer.php?',
+    'https://www.linkedin.com/shareArticle?'
+  ]
+
+  let thisDomain = window.location.hostname
+
+  if (thisDomain.indexOf('www.') === 0) {
+    thisDomain = thisDomain.substr(4)
+  }
+
+  for (const link of links) {
+    const href = link.getAttribute('href')
+
+    if (!href) {
+      continue
+    }
+
+    if (href.indexOf('http://') === 0 || href.indexOf('https://') === 0 || href.indexOf('//') === 0) {
+      let domain = link.hostname
+
+      if (domain.indexOf('www.') === 0) {
+        domain = domain.substr(4)
+      }
+
+      if (domain !== thisDomain) {
+        link.setAttribute('target', '_blank')
+        // Add noopener and 'noreferrer' to work around this:
+        // https://dev.to/ben/the-targetblank-vulnerability-by-example
+        let rel = link.getAttribute('rel')
+        if (!rel) {
+          // will be null if it is not set
+          rel = ''
+        }
+        link.setAttribute('rel', `${rel} noopener noreferrer`)
+      }
+    }
+
+    // Use a popup for social sharing links.
+    for (const prefix of usePopupPrefixes) {
+      if (href.indexOf(prefix) === 0) {
+        link.addEventListener('click', (event) => {
+          event.preventDefault()
+          window.open(href, '_blank', 'width=600,height=300,menubar=0,toolbar=0,status=0')
+        })
+        break
+      }
+    }
+  }
+}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/external-links/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/external-links/index.js
@@ -6,7 +6,7 @@ will have their 'target' attribute set to '_blank'.
 Social media sharing links will show in a popup.
 */
 export default function () {
-  const links = [].slice.call(document.getElementsByTagName('a'))
+  const links = Array.from(document.getElementsByTagName('a'))
 
   // If the link starts with any of these things, we'll open a 600x300 popup
   // window for them.
@@ -41,10 +41,12 @@ export default function () {
         // Add noopener and 'noreferrer' to work around this:
         // https://dev.to/ben/the-targetblank-vulnerability-by-example
         let rel = link.getAttribute('rel')
+        
         if (!rel) {
           // will be null if it is not set
           rel = ''
         }
+        
         link.setAttribute('rel', `${rel} noopener noreferrer`)
       }
     }
@@ -54,8 +56,10 @@ export default function () {
       if (href.indexOf(prefix) === 0) {
         link.addEventListener('click', (event) => {
           event.preventDefault()
+          
           window.open(href, '_blank', 'width=600,height=300,menubar=0,toolbar=0,status=0')
         })
+        
         break
       }
     }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/main.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/main.js
@@ -1,8 +1,10 @@
 import Vue from 'vue'
 import App from './App'
 
+import externalLinks from './external-links'
+
 new Vue(App).$mount('#app')
 
 document.addEventListener('DOMContentLoaded', () => {
-  // Stuff
+  externalLinks()
 })


### PR DESCRIPTION
I think we all agreed this is a reasonable idea!

Explanation: All links that do not point to the same domain are considered external.

'Same domain' is defined as 'same domain, when both are stripped of a leading `www.` string if present'.

As a bonus, it will also open social sharing links (Facebook, Twitter, LinkedIn) in a 600x300 popup (on devices where this is meaningful).