### PR TITLE
Use single quotes consistently in settings.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -1,13 +1,3 @@
-'''
-Production settings for {{cookiecutter.repo_name}} project.
-
-For an explanation of these settings, please see the Django documentation at:
-
-<http://docs.djangoproject.com/en/dev/>
-
-While many of these settings assume sensible defaults, you must provide values
-for the site, database, media and email sections below.
-'''
 from __future__ import unicode_literals
 
 import os

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -1,4 +1,4 @@
-"""
+'''
 Production settings for {{cookiecutter.repo_name}} project.
 
 For an explanation of these settings, please see the Django documentation at:
@@ -7,7 +7,7 @@ For an explanation of these settings, please see the Django documentation at:
 
 While many of these settings assume sensible defaults, you must provide values
 for the site, database, media and email sections below.
-"""
+'''
 from __future__ import unicode_literals
 
 import os
@@ -17,16 +17,16 @@ import sys
 from django_jinja.builtins import DEFAULT_EXTENSIONS
 from social.pipeline import DEFAULT_AUTH_PIPELINE
 
-if platform.python_implementation() == "PyPy":
+if platform.python_implementation() == 'PyPy':
     from psycopg2cffi import compat  # pylint: disable=import-error
     compat.register()
 
 
 # The name of this site.  Used for branding in the online admin area.
 
-SITE_NAME = "{{cookiecutter.project_name}}"
+SITE_NAME = '{{cookiecutter.project_name}}'
 
-SITE_DOMAIN = "{{cookiecutter.domain_name}}"
+SITE_DOMAIN = '{{cookiecutter.domain_name}}'
 
 PREPEND_WWW = True
 
@@ -44,60 +44,60 @@ SUIT_CONFIG = {
 # Database settings.
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": "{{cookiecutter.package_name}}",
-        "USER": "{{cookiecutter.package_name}}",
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': '{{cookiecutter.package_name}}',
+        'USER': '{{cookiecutter.package_name}}',
     }
 }
 
 
 # Absolute path to the directory where all uploaded media files are stored.
 
-MEDIA_ROOT = "/var/www/{{cookiecutter.package_name}}_media"
+MEDIA_ROOT = '/var/www/{{cookiecutter.package_name}}_media'
 
-MEDIA_URL = "/media/"
+MEDIA_URL = '/media/'
 
 FILE_UPLOAD_PERMISSIONS = 0o644
 
 
 # Absolute path to the directory where static files will be collected.
 
-STATIC_ROOT = "/var/www/{{cookiecutter.package_name}}_static"
+STATIC_ROOT = '/var/www/{{cookiecutter.package_name}}_static'
 
-STATIC_URL = "/static/"
+STATIC_URL = '/static/'
 
-NODE_MODULES_ROOT = "/var/www/{{cookiecutter.package_name}}_static"
+NODE_MODULES_ROOT = '/var/www/{{cookiecutter.package_name}}_static'
 
-NODE_MODULES_URL = "/static/"
+NODE_MODULES_URL = '/static/'
 
 
 # Email settings.
 
-EMAIL_HOST = "smtp.mandrillapp.com"
+EMAIL_HOST = 'smtp.mandrillapp.com'
 
-EMAIL_HOST_USER = "developers@onespacemedia.com"
+EMAIL_HOST_USER = 'developers@onespacemedia.com'
 
-EMAIL_HOST_PASSWORD = ""
+EMAIL_HOST_PASSWORD = ''
 
 EMAIL_PORT = 587
 
 EMAIL_USE_TLS = True
 
-SERVER_EMAIL = "{name} <notifications@{domain}>".format(
+SERVER_EMAIL = '{name} <notifications@{domain}>'.format(
     name=SITE_NAME,
     domain=SITE_DOMAIN,
 )
 
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
-EMAIL_SUBJECT_PREFIX = "[%s] " % SITE_NAME
+EMAIL_SUBJECT_PREFIX = '[%s] ' % SITE_NAME
 
 
 # Error reporting settings.  Use these to set up automatic error notifications.
 
 ADMINS = (
-    ("Onespacemedia Errors", "errors@onespacemedia.com"),
+    ('Onespacemedia Errors', 'errors@onespacemedia.com'),
 )
 
 MANAGERS = ()
@@ -107,9 +107,9 @@ SEND_BROKEN_LINK_EMAILS = False
 
 # Locale settings.
 
-TIME_ZONE = "Europe/London"
+TIME_ZONE = 'Europe/London'
 
-LANGUAGE_CODE = "en-gb"
+LANGUAGE_CODE = 'en-gb'
 
 USE_I18N = False
 
@@ -120,50 +120,50 @@ USE_TZ = True
 
 # Auto-discovery of project location.
 
-SITE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-BASE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+SITE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+BASE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))
 
 
 # A list of additional installed applications.
 
 INSTALLED_APPS = [
 
-    "django.contrib.sessions",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    "suit",
-    "django.contrib.admin",
-    "django.contrib.sitemaps",
+    'django.contrib.sessions',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'suit',
+    'django.contrib.admin',
+    'django.contrib.sitemaps',
 
     'flexible_images',
-    "sorl.thumbnail",
-    "compressor",
+    'sorl.thumbnail',
+    'compressor',
 
-    "django_jinja",
+    'django_jinja',
 
-    "cms",
+    'cms',
 
-    "reversion",
-    "historylinks",
-    "watson",
+    'reversion',
+    'historylinks',
+    'watson',
 
-    "cms.apps.pages",
-    "cms.apps.links",
-    "cms.apps.media",
+    'cms.apps.pages',
+    'cms.apps.links',
+    'cms.apps.media',
 
-    {% if cookiecutter.redirects == 'no' %}# {% endif %}"redirects",
+    {% if cookiecutter.redirects == 'no' %}# {% endif %}'redirects',
 
-    {% if cookiecutter.careers == 'no' %}# {% endif %}"{{cookiecutter.package_name}}.apps.careers",
-    "{{cookiecutter.package_name}}.apps.components",
-    {% if cookiecutter.faqs == 'no' %}# {% endif %}"{{cookiecutter.package_name}}.apps.faqs",
-    {% if cookiecutter.footer == 'no' %}# {% endif %}"{{cookiecutter.package_name}}.apps.footer",
-    {% if cookiecutter.news == 'no' %}# {% endif %}"{{cookiecutter.package_name}}.apps.news",
-    {% if cookiecutter.people == 'no' %}# {% endif %}"{{cookiecutter.package_name}}.apps.people",
-    {% if cookiecutter.sections == 'no' %}# {% endif %}"{{cookiecutter.package_name}}.apps.sections",
-    "{{cookiecutter.package_name}}.apps.settings",
-    "{{cookiecutter.package_name}}.apps.site",
+    {% if cookiecutter.careers == 'no' %}# {% endif %}'{{cookiecutter.package_name}}.apps.careers',
+    '{{cookiecutter.package_name}}.apps.components',
+    {% if cookiecutter.faqs == 'no' %}# {% endif %}'{{cookiecutter.package_name}}.apps.faqs',
+    {% if cookiecutter.footer == 'no' %}# {% endif %}'{{cookiecutter.package_name}}.apps.footer',
+    {% if cookiecutter.news == 'no' %}# {% endif %}'{{cookiecutter.package_name}}.apps.news',
+    {% if cookiecutter.people == 'no' %}# {% endif %}'{{cookiecutter.package_name}}.apps.people',
+    {% if cookiecutter.sections == 'no' %}# {% endif %}'{{cookiecutter.package_name}}.apps.sections',
+    '{{cookiecutter.package_name}}.apps.settings',
+    '{{cookiecutter.package_name}}.apps.site',
 
     'server_management',
     'django_extensions',
@@ -174,13 +174,13 @@ INSTALLED_APPS = [
 ]
 
 if sys.version_info[0] == 3:
-    INSTALLED_APPS.remove("server_management")
+    INSTALLED_APPS.remove('server_management')
 
 # Additional static file locations.
 
 STATICFILES_DIRS = (
-    os.path.join(SITE_ROOT, "assets"),  # For webpack_loader
-    os.path.join(SITE_ROOT, "static"),
+    os.path.join(SITE_ROOT, 'assets'),  # For webpack_loader
+    os.path.join(SITE_ROOT, 'static'),
 )
 
 STATICFILES_FINDERS = (
@@ -205,17 +205,17 @@ THUMBNAIL_PRESERVE_FORMAT = True
 # Dispatch settings.
 
 MIDDLEWARE_CLASSES = (
-    {% if cookiecutter.geoip == 'no' %}# {% endif %}"cms.middleware.LocalisationMiddleware",
-    {% if cookiecutter.redirects == 'no' %}# {% endif %}"redirects.middleware.RedirectFallbackMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "watson.middleware.SearchContextMiddleware",
-    "historylinks.middleware.HistoryLinkFallbackMiddleware",
-    "cms.middleware.PublicationMiddleware",
-    "cms.apps.pages.middleware.PageMiddleware",
+    {% if cookiecutter.geoip == 'no' %}# {% endif %}'cms.middleware.LocalisationMiddleware',
+    {% if cookiecutter.redirects == 'no' %}# {% endif %}'redirects.middleware.RedirectFallbackMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'watson.middleware.SearchContextMiddleware',
+    'historylinks.middleware.HistoryLinkFallbackMiddleware',
+    'cms.middleware.PublicationMiddleware',
+    'cms.apps.pages.middleware.PageMiddleware',
 )
 
 PASSWORD_HASHERS = (
@@ -229,17 +229,17 @@ PASSWORD_HASHERS = (
 )
 
 
-ROOT_URLCONF = "{{cookiecutter.package_name}}.urls"
+ROOT_URLCONF = '{{cookiecutter.package_name}}.urls'
 
-WSGI_APPLICATION = "{{cookiecutter.package_name}}.wsgi.application"
+WSGI_APPLICATION = '{{cookiecutter.package_name}}.wsgi.application'
 
 PUBLICATION_MIDDLEWARE_EXCLUDE_URLS = (
-    "^admin/.*",
+    '^admin/.*',
 )
 
-SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 
-MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.CookieStorage"
+MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'
 
 SITE_ID = 1
 
@@ -247,60 +247,60 @@ SITE_ID = 1
 
 TEMPLATES = [
     {
-        "BACKEND": "django_jinja.backend.Jinja2",
-        "DIRS": [
-            os.path.join(SITE_ROOT, "templates"),
+        'BACKEND': 'django_jinja.backend.Jinja2',
+        'DIRS': [
+            os.path.join(SITE_ROOT, 'templates'),
         ],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "match_extension": ".html",
-            "match_regex": r"^(?!admin/|reversion/|registration/).*",
-            "app_dirname": "templates",
-            "newstyle_gettext": True,
-            "extensions": DEFAULT_EXTENSIONS + [
-                "webpack_loader.contrib.jinja2ext.WebpackExtension",
-                "compressor.contrib.jinja2ext.CompressorExtension"
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'match_extension': '.html',
+            'match_regex': r'^(?!admin/|reversion/|registration/).*',
+            'app_dirname': 'templates',
+            'newstyle_gettext': True,
+            'extensions': DEFAULT_EXTENSIONS + [
+                'webpack_loader.contrib.jinja2ext.WebpackExtension',
+                'compressor.contrib.jinja2ext.CompressorExtension'
             ],
-            "bytecode_cache": {
-                "name": "default",
-                "backend": "django_jinja.cache.BytecodeCache",
-                "enabled": False,
+            'bytecode_cache': {
+                'name': 'default',
+                'backend': 'django_jinja.cache.BytecodeCache',
+                'enabled': False,
             },
-            "autoescape": True,
-            "auto_reload": False,
-            "translation_engine": "django.utils.translation",
-            "context_processors": [
-                "django.contrib.auth.context_processors.auth",
-                "django.core.context_processors.debug",
-                "django.core.context_processors.i18n",
-                "django.core.context_processors.media",
-                "django.core.context_processors.static",
-                "django.contrib.messages.context_processors.messages",
-                "django.core.context_processors.request",
-                "cms.context_processors.settings",
-                "cms.apps.pages.context_processors.pages",
+            'autoescape': True,
+            'auto_reload': False,
+            'translation_engine': 'django.utils.translation',
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.core.context_processors.debug',
+                'django.core.context_processors.i18n',
+                'django.core.context_processors.media',
+                'django.core.context_processors.static',
+                'django.contrib.messages.context_processors.messages',
+                'django.core.context_processors.request',
+                'cms.context_processors.settings',
+                'cms.apps.pages.context_processors.pages',
                 'social.apps.django_app.context_processors.backends',
                 'social.apps.django_app.context_processors.login_redirect'
             ]
         }
     },
     {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [
-            os.path.join(SITE_ROOT, "templates"),
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(SITE_ROOT, 'templates'),
         ],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.contrib.auth.context_processors.auth",
-                "django.core.context_processors.debug",
-                "django.core.context_processors.i18n",
-                "django.core.context_processors.media",
-                "django.core.context_processors.static",
-                "django.contrib.messages.context_processors.messages",
-                "django.core.context_processors.request",
-                "cms.context_processors.settings",
-                "cms.apps.pages.context_processors.pages",
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.core.context_processors.debug',
+                'django.core.context_processors.i18n',
+                'django.core.context_processors.media',
+                'django.core.context_processors.static',
+                'django.contrib.messages.context_processors.messages',
+                'django.core.context_processors.request',
+                'cms.context_processors.settings',
+                'cms.apps.pages.context_processors.pages',
                 'social.apps.django_app.context_processors.backends',
                 'social.apps.django_app.context_processors.login_redirect'
             ]
@@ -311,11 +311,11 @@ TEMPLATES = [
 
 # Namespace for cache keys, if using a process-shared cache.
 
-CACHE_MIDDLEWARE_KEY_PREFIX = "{{cookiecutter.package_name}}"
+CACHE_MIDDLEWARE_KEY_PREFIX = '{{cookiecutter.package_name}}'
 
 CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': '127.0.0.1:11211',
     }
 }
@@ -323,7 +323,7 @@ CACHES = {
 
 # A secret key used for cryptographic algorithms.
 
-SECRET_KEY = " "
+SECRET_KEY = ' '
 
 
 WYSIWYG_OPTIONS = {
@@ -333,15 +333,15 @@ WYSIWYG_OPTIONS = {
     # Main plugins to load, this has been stripped to match the toolbar
     # See https://www.tinymce.com/docs/get-started/work-with-plugins/
     'plugins': [
-        "advlist autolink link image lists charmap hr anchor pagebreak",
-        "wordcount visualblocks visualchars code fullscreen cmsimage hr template",
-        "table contextmenu directionality paste textcolor colorpicker textpattern"
+        'advlist autolink link image lists charmap hr anchor pagebreak',
+        'wordcount visualblocks visualchars code fullscreen cmsimage hr template',
+        'table contextmenu directionality paste textcolor colorpicker textpattern'
     ],
 
     # Items to display on the 3 toolbar lines
-    'toolbar1': "code | cut copy paste pastetext | undo redo | bullist numlist | link unlink anchor cmsimage | blockquote charmap",
-    'toolbar2': "template styleselect formatselect | bold italic underline hr | alignleft aligncenter alignright | table | removeformat | subscript superscript",
-    'toolbar3': "",
+    'toolbar1': 'code | cut copy paste pastetext | undo redo | bullist numlist | link unlink anchor cmsimage | blockquote charmap',
+    'toolbar2': 'template styleselect formatselect | bold italic underline hr | alignleft aligncenter alignright | table | removeformat | subscript superscript',
+    'toolbar3': '',
 
     # Display menubar with dropdowns
     'menubar': False,
@@ -464,7 +464,7 @@ SOCIAL_AUTH_PIPELINE = DEFAULT_AUTH_PIPELINE + (
 
 SILENCED_SYSTEM_CHECKS = []
 
-{% if cookiecutter.geoip == 'no' %}# {% endif %}GEOIP_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../geoip/"))
+{% if cookiecutter.geoip == 'no' %}# {% endif %}GEOIP_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../geoip/'))
 
 if 'test' in sys.argv:
     # The CMS tests use test-only models, which won't be loaded if we only load
@@ -480,7 +480,7 @@ if 'test' in sys.argv:
             return True
 
         def __getitem__(self, item):
-            return "notmigrations"
+            return 'notmigrations'
 
     MIGRATION_MODULES = DisableMigrations()
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
@@ -1,6 +1,6 @@
-"""
+'''
 Settings for local development.
-"""
+'''
 
 import os
 import os.path
@@ -11,37 +11,37 @@ from .base import *  # pylint: disable=unused-wildcard-import,wildcard-import
 
 DEBUG = True
 
-TEMPLATES[0]["OPTIONS"]["auto_reload"] = DEBUG
+TEMPLATES[0]['OPTIONS']['auto_reload'] = DEBUG
 
 # Save media files to the user's Sites folder.
 
-MEDIA_ROOT = os.path.expanduser(os.path.join("~/Sites", SITE_DOMAIN, "media"))
-STATIC_ROOT = os.path.expanduser(os.path.join("~/Sites", SITE_DOMAIN, "static"))
-NODE_MODULES_ROOT = os.path.expanduser(os.path.join("~/Workspace/{{cookiecutter.package_name}}", "node_modules"))
+MEDIA_ROOT = os.path.expanduser(os.path.join('~/Sites', SITE_DOMAIN, 'media'))
+STATIC_ROOT = os.path.expanduser(os.path.join('~/Sites', SITE_DOMAIN, 'static'))
+NODE_MODULES_ROOT = os.path.expanduser(os.path.join('~/Workspace/{{cookiecutter.package_name}}', 'node_modules'))
 
 
 # Use local server.
 
-SITE_DOMAIN = "localhost:8000"
+SITE_DOMAIN = 'localhost:8000'
 
 ALLOWED_HOSTS = [
     # Django's defaults.
-    "127.0.0.1",
-    "localhost",
-    "::1",
+    '127.0.0.1',
+    'localhost',
+    '::1',
     # For compatibility with Browsersync.
-    "0.0.0.0",
+    '0.0.0.0',
 ]
 
 PREPEND_WWW = False
 
 # Optional separate database settings
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "HOST": "localhost",
-        "NAME": "{{cookiecutter.package_name}}",
-        "USER": os.getlogin(),
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'HOST': 'localhost',
+        'NAME': '{{cookiecutter.package_name}}',
+        'USER': os.getlogin(),
     },
 }
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/local.py
@@ -1,7 +1,3 @@
-'''
-Settings for local development.
-'''
-
 import os
 import os.path
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/production.py
@@ -8,9 +8,9 @@ INSTALLED_APPS += (
 )
 
 OPBEAT = {
-    "ORGANIZATION_ID": "dde034beb33d4b77bb9937c39f0c158f",
-    "APP_ID": "{{cookiecutter.opbeat_app_id}}",
-    "SECRET_TOKEN": "{{cookiecutter.opbeat_secret_token}}"
+    'ORGANIZATION_ID': 'dde034beb33d4b77bb9937c39f0c158f',
+    'APP_ID': '{{cookiecutter.opbeat_app_id}}',
+    'SECRET_TOKEN': '{{cookiecutter.opbeat_secret_token}}'
 }
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
The current settings files uses a mix of single and double quotes. One of them should be used consistently, and single quotes are as good as any (and is also consistent with our JS and CSS standards). This amends the settings to use the latter consistently.