### PR TITLE
Use single quotes consistently, everywhere.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/components/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/components/admin.py
@@ -24,5 +24,5 @@ class CallToActionAdmin(admin.ModelAdmin):
 
         return ', '.join(pages_used)
 
-    pages_used_on.short_description = "Pages used on"
+    pages_used_on.short_description = 'Pages used on'
     pages_used_on.allow_tags = True

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/settings/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/settings/admin.py
@@ -7,10 +7,10 @@ from .models import Setting
 class SettingAdmin(admin.ModelAdmin):
     prepopulated_fields = {'key': ['name']}
 
-    list_display = ["name", "key"]
+    list_display = ['name', 'key']
 
     def get_form(self, request, obj=None, **kwargs):
-        if getattr(settings, "SETTINGS_ADMINS", None) is not None:
+        if getattr(settings, 'SETTINGS_ADMINS', None) is not None:
             if obj and request.user.username not in settings.SETTINGS_ADMINS:
                 self.exclude = ['name', 'key']
                 self.prepopulated_fields = {}
@@ -18,12 +18,12 @@ class SettingAdmin(admin.ModelAdmin):
         return super(SettingAdmin, self).get_form(request, obj, **kwargs)
 
     def has_add_permission(self, request):
-        if getattr(settings, "SETTINGS_ADMINS", None) is not None:
+        if getattr(settings, 'SETTINGS_ADMINS', None) is not None:
             return request.user.username in settings.SETTINGS_ADMINS
         return super(SettingAdmin, self).has_add_permission(request)
 
     def has_delete_permission(self, request, obj=None):
-        if getattr(settings, "SETTINGS_ADMINS", None) is not None:
+        if getattr(settings, 'SETTINGS_ADMINS', None) is not None:
             return request.user.username in settings.SETTINGS_ADMINS
         return super(SettingAdmin, self).has_delete_permission(request, obj)
 
@@ -31,7 +31,7 @@ class SettingAdmin(admin.ModelAdmin):
         return obj.name
 
     class Media:
-        js = ("/static/settings/js/admin/fields.js",)
+        js = ('/static/settings/js/admin/fields.js',)
 
 
 admin.site.register(Setting, SettingAdmin)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/settings/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/settings/models.py
@@ -8,12 +8,12 @@ class Setting(models.Model):
 
     name = models.CharField(
         max_length=1024,
-        help_text="Name of the setting",
+        help_text='Name of the setting',
     )
 
     key = models.CharField(
         max_length=1024,
-        help_text="The key used to reference the setting",
+        help_text='The key used to reference the setting',
     )
 
     type = models.CharField(

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/models.py
@@ -4,6 +4,6 @@
 # class Content(ContentBase):
 
 #     content_primary = HtmlField(
-#         "primary content",
+#         'primary content',
 #         blank=True
 #     )

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/templatetags/site.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/templatetags/site.py
@@ -18,6 +18,6 @@ def get_navigation_json(context, pages, section=None):
 def frontend_templates():
     return mark_safe([
         str(f[:-5])
-        for f in os.listdir(os.path.join(settings.TEMPLATES[0]["DIRS"][0], 'frontend'))
+        for f in os.listdir(os.path.join(settings.TEMPLATES[0]['DIRS'][0], 'frontend'))
         if f[:1] != '_'
     ])

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/urls.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/urls.py
@@ -1,5 +1,3 @@
-'''URL config for {{cookiecutter.repo_name}} project.'''
-
 from cms.forms import CMSPasswordChangeForm
 from cms.sitemaps import registered_sitemaps
 from cms.views import TextTemplateView

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/urls.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/urls.py
@@ -1,4 +1,4 @@
-"""URL config for {{cookiecutter.repo_name}} project."""
+'''URL config for {{cookiecutter.repo_name}} project.'''
 
 from cms.forms import CMSPasswordChangeForm
 from cms.sitemaps import registered_sitemaps
@@ -21,22 +21,22 @@ urlpatterns = [
     url(r'^admin/password_change/$', 'django.contrib.auth.views.password_change',
         {'password_change_form': CMSPasswordChangeForm}, name='password_change'),
     url(r'^admin/password_change/done/$', 'django.contrib.auth.views.password_change_done', name='password_change_done'),
-    url(r"^admin/", include(admin.site.urls)),
+    url(r'^admin/', include(admin.site.urls)),
     url(r'^admin/', include('social.apps.django_app.urls', namespace='social')),
-    {% if cookiecutter.sections == 'no' %}# {% endif %}url(r'^admin/pages/page/sections.js$', sections_js, name="admin_sections_js"),
+    {% if cookiecutter.sections == 'no' %}# {% endif %}url(r'^admin/pages/page/sections.js$', sections_js, name='admin_sections_js'),
 
     # Permalink redirection service.
-    url(r"^r/(?P<content_type_id>\d+)-(?P<object_id>[^/]+)/$", "django.contrib.contenttypes.views.shortcut", name="permalink_redirect"),
+    url(r'^r/(?P<content_type_id>\d+)-(?P<object_id>[^/]+)/$', 'django.contrib.contenttypes.views.shortcut', name='permalink_redirect'),
 
     # Google sitemap service.
-    url(r"^sitemap.xml$", "django.contrib.sitemaps.views.index", {"sitemaps": registered_sitemaps}),
-    url(r"^sitemap-(?P<section>.+)\.xml$", "django.contrib.sitemaps.views.sitemap", {"sitemaps": registered_sitemaps}),
+    url(r'^sitemap.xml$', 'django.contrib.sitemaps.views.index', {'sitemaps': registered_sitemaps}),
+    url(r'^sitemap-(?P<section>.+)\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': registered_sitemaps}),
 
     # Basic robots.txt.
-    url(r"^robots.txt$", TextTemplateView.as_view(template_name="robots.txt")),
+    url(r'^robots.txt$', TextTemplateView.as_view(template_name='robots.txt')),
 
     # There's no favicon here!
-    url(r"^favicon.ico$", generic.RedirectView.as_view(permanent=True)),
+    url(r'^favicon.ico$', generic.RedirectView.as_view(permanent=True)),
 ] + static(
     settings.MEDIA_URL, document_root=settings.MEDIA_ROOT
 ) + static(
@@ -46,11 +46,11 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += [
-        url(r"^404/$", generic.TemplateView.as_view(template_name="404.html")),
-        url(r"^500/$", generic.TemplateView.as_view(template_name="500.html")),
+        url(r'^404/$', generic.TemplateView.as_view(template_name='404.html')),
+        url(r'^500/$', generic.TemplateView.as_view(template_name='500.html')),
         url(r'^frontend/$', FrontendView.as_view()),
         url(r'^frontend/(?P<slug>[\w-]+)/$', FrontendView.as_view())
     ]
 
 
-handler500 = "cms.views.handler500"
+handler500 = 'cms.views.handler500'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/wsgi.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/wsgi.py
@@ -1,18 +1,3 @@
-'''
-WSGI config for {{cookiecutter.repo_name}} project.
-
-This module contains the WSGI application used by Django's development server
-and any production WSGI deployments. It should expose a module-level variable
-named ``application``. Django's ``runserver`` and ``runfcgi`` commands discover
-this application via the ``WSGI_APPLICATION`` setting.
-
-Usually you will have the standard Django WSGI application here, but it also
-might make sense to replace the whole Django WSGI application with a custom one
-that later delegates to the Django one. For example, you could introduce WSGI
-middleware here, or combine a Django application with an application of another
-framework.
-'''
-
 import os
 
 # This application object is used by any WSGI server configured to use this
@@ -25,9 +10,5 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{cookiecutter.package_name}}.s
 # For HTTPS sites, enable these.
 # os.environ.setdefault('HTTPS', 'on')
 # os.environ.setdefault('wsgi.url_scheme', 'https')
-
-# if os.environ['DJANGO_SETTINGS_MODULE'] != '{{cookiecutter.package_name}}.settings.local':
-#     import newrelic.agent
-#     newrelic.agent.initialize('newrelic.ini')
 
 application = get_wsgi_application()

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/wsgi.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/wsgi.py
@@ -1,4 +1,4 @@
-"""
+'''
 WSGI config for {{cookiecutter.repo_name}} project.
 
 This module contains the WSGI application used by Django's development server
@@ -11,8 +11,8 @@ might make sense to replace the whole Django WSGI application with a custom one
 that later delegates to the Django one. For example, you could introduce WSGI
 middleware here, or combine a Django application with an application of another
 framework.
+'''
 
-"""
 import os
 
 # This application object is used by any WSGI server configured to use this
@@ -20,10 +20,10 @@ import os
 # setting points here.
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{cookiecutter.package_name}}.settings.production")
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{cookiecutter.package_name}}.settings.production')
 
 # For HTTPS sites, enable these.
-# os.environ.setdefault('HTTPS', "on")
+# os.environ.setdefault('HTTPS', 'on')
 # os.environ.setdefault('wsgi.url_scheme', 'https')
 
 # if os.environ['DJANGO_SETTINGS_MODULE'] != '{{cookiecutter.package_name}}.settings.local':


### PR DESCRIPTION
Following on from #69. Use single quotes everywhere to replace the mixture of double and single quotes.