### PR TITLE
Remove yarn.lock from .gitignore.

### DIFF
--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -66,4 +66,3 @@ bower_components/
 webpack-stats.json
 
 */static/build
-yarn.lock


### PR DESCRIPTION
From https://yarnpkg.com/en/docs/yarn-lock:

> All yarn.lock files should be checked into source control (e.g. git or mercurial). This allows Yarn to install the same exact dependency tree across all machines, whether it be your coworker’s laptop or a CI server.