### PR TITLE
Move webpack bundles out of compressor

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -90,9 +90,8 @@
       </div>
     {% endblock %}
 
-    {% compress js %}
-      {{ render_bundle('vendor', 'js') }}
-    {% endcompress %}
+    {{ render_bundle('vendor', 'js') }}
+    {{ render_bundle('app', 'js') }}
 
     {% compress js %}
       {% block compressed_js_first %}{% endblock %}
@@ -104,7 +103,6 @@
         window.navigationData = {{ nav | safe }};
       </script>
 
-      {{ render_bundle('app', 'js') }}
       <script src="{{ static('flexible-images/flexible-images.js') }}"></script>
 
       {% block compressed_js_last %}{% endblock %}


### PR DESCRIPTION
This lets us utilise lazy loading modules properly. When they are inside compressor all the lazy loaded bundles end up getting compressed into 1 so the JS errors when it tries to find one.