### PR TITLE
Add SECURE_PROXY_SSL_HEADER to settings.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -26,8 +26,6 @@ ALLOWED_HOSTS = [
     'www.{{cookiecutter.staging_subdomain}}.onespace.media',
 ]
 
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
 SUIT_CONFIG = {
     'ADMIN_NAME': SITE_NAME,
     'MENU_EXCLUDE': ['default'],

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -26,6 +26,8 @@ ALLOWED_HOSTS = [
     'www.{{cookiecutter.staging_subdomain}}.onespace.media',
 ]
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 SUIT_CONFIG = {
     'ADMIN_NAME': SITE_NAME,
     'MENU_EXCLUDE': ['default'],

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/production.py
@@ -3,6 +3,8 @@ from .base import *  # pylint: disable=unused-wildcard-import,wildcard-import
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 INSTALLED_APPS += (
     'opbeat.contrib.django',
 )


### PR DESCRIPTION
As we are using HTTPS by default for all sites, and the latest server-management [adds the X-Forwarded-Proto header to the nginx config](https://github.com/onespacemedia/server-management/commit/47f96a94dd6281dc6d3088555d7d0eb7eedc957b), it makes sense to have this one-line change which makes `request.is_secure()` work (and consequently, canonical URLs and such use HTTPS as well).