### PR TITLE
Trim the external link href

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils.js
@@ -23,7 +23,7 @@ export function externalLinks () {
   }
 
   for (const link of links) {
-    const href = link.getAttribute('href')
+    const href = link.getAttribute('href').trim()
 
     if (!href) {
       continue


### PR DESCRIPTION
This fixes an issue where a URL is entered with a leading space.  Browsers will trim this space and navigate to the page without an issue, but our external links library will consider it to be an internal link (because it doesn't start with 'http://').  Trimming the href will allow the string matching to work as expected.