### PR TITLE
Unregister Python Social Auth models

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/__init__.py
@@ -1,1 +1,2 @@
 """Site-specific content, templatetags and such."""
+default_app_config = '{{cookiecutter.package_name}}.apps.site.apps.SiteAppConfig'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/apps.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/apps.py
@@ -1,0 +1,19 @@
+from django.apps import AppConfig
+from django.contrib import admin
+
+
+class SiteAppConfig(AppConfig):
+    name = '{{cookiecutter.package_name}}.apps.site'
+
+    def ready(self):
+        # Unregister python social auth models (not really needed or useful).
+        #
+        # Import needs to be here as it won't work at the top level of the
+        # file.
+        from social.apps.django_app.default.models import Association, Nonce, UserSocialAuth
+
+        for model in [Association, Nonce, UserSocialAuth]:
+            try:
+                admin.site.unregister(model)
+            except admin.sites.NotRegistered:
+                pass


### PR DESCRIPTION
They aren't particularly useful, and it saves us explaining what 'Nonce' is. It can be excluded from the menu in settings, but that does not stop it from appearing on the admin homepage. This PR unregisters the models entirely.