### PR TITLE
Ensure that IE11 never renders in compatibility mode.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="description" content="{% block meta_description %}{{ get_meta_description() }}{% endblock %}">


### PR DESCRIPTION
This avoids rare situations in which IE11 decides it is on an Intranet and that it is really Internet Explorer 8.