### PR TITLE
Upgrade setuptools in CircleCI.

### DIFF
--- a/{{cookiecutter.repo_name}}/circle.yml
+++ b/{{cookiecutter.repo_name}}/circle.yml
@@ -7,6 +7,7 @@ dependencies:
     - /home/ubuntu/nvm/versions/node/v6.9.0/bin
     - /home/ubuntu/nvm/versions/node/v6.9.0/lib/node_modules
   override:
+    - pip install -U setuptools
     - pip install --disable-pip-version-check -r requirements.txt
     - npm install --global yarn
     - yarn add stylelint@7.11.0 stylelint-order@0.5.0 eslint@4.0.0 eslint-config-standard@10.2.1 eslint-config-prettier@2.1.1 eslint-plugin-standard@3.0.1 eslint-plugin-html@3.0.0 eslint-plugin-prettier@2.1.2 babel-eslint@7.2.3 standard@10.0.2


### PR DESCRIPTION
The `setuptools` in the default CircleCI does not work with Python 3.6 (see https://github.com/pypa/setuptools/issues/866). This manifests itself as Circle being unable to install `python-memcached`.

This solves the problem by upgrading to a newer, fixed `setuptools`.