### PR TITLE
Remove CSRF_COOKIE_HTTPONLY and move CSRF_COOKIE_SECURE to production.py

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -314,8 +314,6 @@ CACHES = {
 # A secret key used for cryptographic algorithms.
 
 SECRET_KEY = ' '
-CSRF_COOKIE_SECURE = True
-CSRF_COOKIE_HTTPONLY = True
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 WYSIWYG_OPTIONS = {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/production.py
@@ -2,6 +2,7 @@ from .base import *  # pylint: disable=unused-wildcard-import,wildcard-import
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
+CSRF_COOKIE_SECURE = True
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/1.11/ref/settings/#csrf-cookie-httponly it mentions this isn't really needed and prevents our AJAX requests from being able to read the CSRF