### PR TITLE
[#181, #180] A few frontend build fixes

### DIFF
--- a/{{cookiecutter.repo_name}}/gulpfile.js/lib/getEnabledTasks.js
+++ b/{{cookiecutter.repo_name}}/gulpfile.js/lib/getEnabledTasks.js
@@ -1,5 +1,4 @@
 var config  = require('../config')
-var compact = require('lodash/compact')
 
 // Grouped by what can run in parallel
 var assetTasks = ['fonts', 'iconFont', 'images', 'svgSprite']
@@ -31,7 +30,7 @@ module.exports = function(env) {
   }
 
   return {
-    assetTasks: compact(assetTasks.map(matchFilter).filter(exists)),
-    codeTasks: compact(codeTasks.map(matchFilter).filter(exists))
+    assetTasks: assetTasks.map(matchFilter).filter(exists),
+    codeTasks: codeTasks.map(matchFilter).filter(exists)
   }
 }

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -112,7 +112,8 @@
       ],
       "**/!(migrations|tests)/*.py": [
         "pylint --load-plugins pylint_django,pylint_mccabe -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code,fixme --reports=n",
-        "isort --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/*"
+        "isort --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/*",
+        "git add"
       ]
     }
   },

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -106,7 +106,7 @@
         "git add"
       ],
       "**/!(definitions)/*.css": [
-        "prettier --write --single-quote",
+        "prettier-standard --write",
         "stylelint",
         "git add"
       ],

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -106,7 +106,7 @@
         "git add"
       ],
       "**/!(definitions)/*.css": [
-        "prettier --write",
+        "prettier --write --single-quote",
         "stylelint",
         "git add"
       ],

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
@@ -1,5 +1,5 @@
 /* This is used for multiple base styles so we need selector types */
-/* stylelint-disable selector-no-type, selector-no-universal */
+/* stylelint-disable selector-max-type, selector-max-universal */
 /*
 |--------------------------------------------------------------------------
 | Redefine

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/definitions/property-definitions.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/definitions/property-definitions.css
@@ -83,12 +83,9 @@
     border: 1px solid transparent;
     color: #fff;
 
-    /* Style reasons */
-    /* stylelint-disable */
     transition: background-color var(--Global_Transition),
                 border var(--Global_Transition),
                 color var(--Global_Transition);
-    /* stylelint-enable */
   };
 
   /*

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg.css
@@ -2,7 +2,7 @@
 @import 'base/define.css';
 
 /* We are targetting the admin's iframe */
-/* stylelint-disable selector-no-type */
+/* stylelint-disable selector-max-type */
 body {
   @import 'wysiwyg/wysiwyg.css';
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg/wysiwyg.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg/wysiwyg.css
@@ -10,7 +10,7 @@
 */
 
 /* We are styling root elements so we need access to type */
-/* stylelint-disable selector-no-type */
+/* stylelint-disable selector-max-type */
 p {
   margin-bottom: 1vr;
 }
@@ -73,7 +73,7 @@ ul {
 }
 
 /* We want every first and last item to never have their relative margin */
-/* stylelint-disable selector-no-universal, declaration-no-important */
+/* stylelint-disable selector-max-universal, declaration-no-important */
 > *:first-child {
   margin-top: 0 !important;
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/vue/components/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/vue/components/index.js
@@ -1,9 +1,7 @@
 import FrontendSwitcher from './frontend-switcher/FrontendSwitcher.vue'
-import LazyImage from './images/LazyImage.vue'
 import MobileNav from './mobile-nav/MobileNav.vue'
 
 export default {
   FrontendSwitcher,
-  LazyImage,
   MobileNav
 }


### PR DESCRIPTION
* Update stylelint-disable lines to use `selector-max-type` and `selector-max-universal` rather than `selector-no-*`.
* Remove a reference to a dead Vue component.
* Force prettier to use single quotes on CSS - it was converting single quotes to double quotes which was causing pre-commits to fail.