### PR TITLE
Exclude sitemap.xml and its friends from Jinja2 processing.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -244,7 +244,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'match_extension': '.html',
-            'match_regex': r'^(?!admin/|reversion/|registration/|debug_toolbar/).*',
+            'match_regex': r'^(?!admin/|reversion/|registration/|sitemap.*\.xml|debug_toolbar/).*',
             'app_dirname': 'templates',
             'newstyle_gettext': True,
             'extensions': DEFAULT_EXTENSIONS + [

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -244,7 +244,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'match_extension': '.html',
-            'match_regex': r'^(?!admin/|reversion/|registration/|sitemap.*\.xml|debug_toolbar/).*',
+            'match_regex': r'^(?!admin/|reversion/|registration/|sitemap\.xml|debug_toolbar/).*',
             'app_dirname': 'templates',
             'newstyle_gettext': True,
             'extensions': DEFAULT_EXTENSIONS + [


### PR DESCRIPTION
This fixes an error wherein Jinja2 complains about `{% spaceless %}` in the CMS sitemap template.