### PR TITLE
Force sorl-thumbnail==12.4a1.

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -19,6 +19,7 @@ paramiko==1.16.0
 Pillow
 python-memcached
 social-auth-app-django
+sorl-thumbnail==12.4a1
 requests
 sorl-thumbnail
 Werkzeug


### PR DESCRIPTION
Older versions have no migrations so they don't work with Django 1.11.x (which no longer falls back to `syncdb` behaviour for unmigrated apps).