### PR TITLE
Fix usage of `get_fields` in sections app

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
@@ -43,7 +43,7 @@ def get_section_name(obj):
 
 
 def sections_js(request):
-    model_fields = SectionBase._meta.get_fields()
+    model_fields = [f.name for f in SectionBase._meta.get_fields()]
     # Since our sections aren't at the top level we'll need to create an array
     # of them when we are iterating
     sections = []

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
@@ -42,27 +42,31 @@ def get_section_name(obj):
     return obj[0][0].upper() + obj[0][1:].replace('-', ' ')
 
 
+def get_section_types_flat():
+    '''Gets a list of section types as a flat list of dictionaries.'''
+    types = []
+    # Loop section groups.
+    for group in SECTION_TYPES:
+        # Every section that appears in the optgroup
+        for section_type in group[1]['sections']:
+            types.append({
+                'slug': section_type[0],
+                'name': get_section_name(section_type),
+                'fields': section_type[1].get('fields', [])
+            })
+    return types
+
+
 def sections_js(request):
     model_fields = [f.name for f in SectionBase._meta.get_fields()]
     # Since our sections aren't at the top level we'll need to create an array
     # of them when we are iterating
-    sections = []
+    sections = get_section_types_flat()
 
-    # Each optgroup we define
-    for group in SECTION_TYPES:
-        # Every section that appears in the optgroup
-        for section_type in group[1]['sections']:
-            fields = section_type[1].get('fields', [])
-
-            # We've got a section so lets add it to the sections list
-            sections.append({
-                'name': section_type[0],
-                'fields': fields
-            })
-
-            for field in fields:
-                if field not in model_fields:
-                    print(f"NOTE: Field `{field}` is referenced by section type `{section_type[0]}`, but doesn't exist.")
+    for section_type in sections:
+        for field in section_type['fields']:
+            if field not in model_fields:
+                print(f"NOTE: Field `{field}` is referenced by section type `{section_type['name']}`, but doesn't exist.")
 
     return render_to_response('admin/pages/page/sections.js', {
         'types': sections,

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/templates/admin/pages/page/sections.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/templates/admin/pages/page/sections.js
@@ -19,7 +19,7 @@ $(window).load(function() {
     var types = {
       '': [],
       {% for type in types %}
-      '{{ type.name }}': {{ type.fields|default:'[]'|safe }}{% if not forloop.last %},{% endif %}
+      '{{ type.slug }}': {{ type.fields|default:'[]'|safe }}{% if not forloop.last %},{% endif %}
       {% endfor %}
     };
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/tests/test_models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/tests/test_models.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from ..models import SectionBase, get_section_types_flat
+
+
+class SectionModelsTestCase(TestCase):
+    def test_get_section_types_flat(self):
+        section_types = get_section_types_flat()
+        self.assertIsInstance(section_types, list)
+        self.assertIsInstance(section_types[0], dict)
+
+    def test_section_fields(self):
+        section_fields = [f.name for f in SectionBase._meta.get_fields()]
+        section_types = get_section_types_flat()
+        for section_type in section_types:
+            for field in section_type['fields']:
+                self.assertIn(field, section_type['fields'])


### PR DESCRIPTION
The 'does this section type have this field' check was previously checking for the field name in `SectionBase._meta.get_fields()`, which in 1.11  returns as a list of actual model fields, not their name, thus the console was being splattered with warnings about field names being missing. This fixes it with `model_fields = [f.name for f in SectionBase._meta.get_fields()]`.