### PR TITLE
Lazy image object fit detection fix for Edge

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/lazy-image.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/lazy-image.css
@@ -51,7 +51,7 @@
   background-position: center;
   background-size: cover;
 
-  @supports (object-fits: cover) {
+  @supports (object-fit: cover) {
     display: none;
   }
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/lazy-image.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/lazy-image.css
@@ -44,9 +44,16 @@
   }
 }
 
-.img-Image_Image-ie {
+.img-Image_Image-noObjectFit {
+  /* Fallback for IE and Edge */
+  display: block;
+
   background-position: center;
   background-size: cover;
+
+  @supports (object-fits: cover) {
+    display: none;
+  }
 }
 
 .img-Image_Image-blurred {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/lazy-image.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/lazy-image.js
@@ -18,13 +18,13 @@ export default class LazyImage {
     )
     const smallImage = node.querySelector('.img-Image_Image-small')
     const largeImage = node.querySelector('.img-Image_Image-large')
-    const ieImage = node.querySelector('.img-Image_Image-ie')
+    const fallbackImage = node.querySelector('.img-Image_Image-noObjectFit')
 
     if (this.supportsObjectFit) {
       smallImage.onload = () => smallImage.classList.add(this.loadedClass)
       largeImage.onload = () => largeImage.classList.add(this.loadedClass)
     } else {
-      largeImage.onload = () => ieImage.classList.add(this.loadedClass)
+      largeImage.onload = () => fallbackImage.classList.add(this.loadedClass)
     }
 
     fragment.appendChild(node)
@@ -34,7 +34,7 @@ export default class LazyImage {
 
   createNode (blurred = true) {
     const fallbackEl = `
-      <div class="img-Image_Image img-Image_Image-ie"
+      <div class="img-Image_Image img-Image_Image-noObjectFit"
            style="background-image: url(${this.largeImageUrl});"></div>`
 
     let imageClass = 'img-Image_Image img-Image_Image-small'


### PR DESCRIPTION
This changes the way lazy image detects `object-fit` support. Previously, the Javascript was testing for it by seeing if `object-fit` was in the document style (which would not be the case on Edge <= 15), but then applied IE11-specific browser hack to show the fallback which Edge ignored.

This changes it to show the fallback in the default rule, then uses `@supports (object-fit: cover)` to hide the fallback.

This fixes lazy images in Edge <= 15 (about 2% usage globally).