### PR TITLE
[#99] Make Argon2 the preferred password hasher.

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,5 +1,4 @@
 argon2-cffi
-bcrypt
 django>=1.11,<1.12
 django-cachalot
 django-compressor

--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,3 +1,4 @@
+argon2-cffi
 bcrypt
 django>=1.11,<1.12
 django-cachalot

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -210,13 +210,6 @@ MIDDLEWARE_CLASSES = (
 
 PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.Argon2PasswordHasher',
-    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
-    'django.contrib.auth.hashers.BCryptPasswordHasher',
-    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
-    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
-    'django.contrib.auth.hashers.SHA1PasswordHasher',
-    'django.contrib.auth.hashers.MD5PasswordHasher',
-    'django.contrib.auth.hashers.CryptPasswordHasher',
 )
 
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -209,6 +209,7 @@ MIDDLEWARE_CLASSES = (
 )
 
 PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
     'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
     'django.contrib.auth.hashers.BCryptPasswordHasher',
     'django.contrib.auth.hashers.PBKDF2PasswordHasher',


### PR DESCRIPTION
As #99 has been around for a while :) Tested on Bradfield, works.

As this is the project template which I don't think we have ever used to upgrade an existing installation, should I just remove all the other hashers? It doesn't actually *hurt* them being there of course, as Argon2 will be used for all new accounts.