### PR TITLE
Sections app: Change the default link field.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/admin.py
@@ -9,6 +9,7 @@ class ContentSectionInline(SortableStackedInline):
     model = ContentSection
     extra = 0
     filter_horizontal = ['people']
+    fk_name = 'page'
 
     class Media(object):
         js = [reverse_lazy('admin_sections_js')]


### PR DESCRIPTION
It's not always a 'button', so rename it appropriately, as we seem to do this in most projects early on :)

Also add a link page option for ease of use and handle PublicationManager throwing 404s on this, which comes up from time to time.