### PR TITLE
Don't show 'Save and continue editing', etc, on admin popup windows.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/admin/submit_line.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/admin/submit_line.html
@@ -1,11 +1,13 @@
 {% load i18n admin_urls suit_tags %}
 <div class="submit-row clearfix">
-  {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save">{% trans 'Save' %}</button>{% endif %}
+  {% if show_save %}
+    <button type="submit" class="btn btn-high btn-info" name="_save">{% trans 'Save' %}</button>
 
-  {% if not '_popup' in request.GET %}
-    <button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>
-    <button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>
-    <button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>
+    {% if not '_popup' in request.GET %}
+      <button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>
+      <button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>
+      <button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>
+    {% endif %}
   {% endif %}
 
   {% if show_delete_link %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/admin/submit_line.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/admin/submit_line.html
@@ -1,9 +1,12 @@
 {% load i18n admin_urls suit_tags %}
 <div class="submit-row clearfix">
   {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save">{% trans 'Save' %}</button>{% endif %}
-  <button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>
-  <button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>
-  <button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>
+
+  {% if not '_popup' in request.GET %}
+    <button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>
+    <button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>
+    <button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>
+  {% endif %}
 
   {% if show_delete_link %}
     {% if '1.9'|django_version_lt %}


### PR DESCRIPTION
....as using these just closes the window after you've saved, so they don't do anything 'Save' does not.