### PR TITLE
Add stripped-down error pages.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/error-page.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/error-page.css
@@ -1,0 +1,49 @@
+/*
+|--------------------------------------------------------------------------
+| Error pages
+|--------------------------------------------------------------------------
+| Styles for stripped-down 404 and 500 pages.
+|
+| @namespace: .err-
+|
+*/
+.err-ErrorBody {
+  margin: 0;
+  padding: 0;
+}
+
+.err-Error {
+  justify-content: center;
+
+  display: flex;
+  width: 100%;
+  height: 100vh;
+
+  color: #fff;
+}
+
+.err-Error_Container {
+  position: relative;
+  z-index: 1;
+
+  max-width: 500px;
+  /* use this rather than align-items: center on the parent as this scales
+  down to really small sizes more gracefully (content doesn't go off-screen) */
+  margin-top: auto;
+  margin-bottom: auto;
+  padding: 2vr var(--Grid_Gutter);
+
+  text-align: center;
+}
+
+.err-Error_Description {
+  margin-top: 1vr;
+}
+
+.err-Error_Footer {
+  margin-top: 1vr;
+}
+
+.err-Error_FooterLink {
+  @include Button();
+}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/error-page.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/error-page.css
@@ -7,11 +7,6 @@
 | @namespace: .err-
 |
 */
-.err-ErrorBody {
-  margin: 0;
-  padding: 0;
-}
-
 .err-Error {
   justify-content: center;
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/404.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/404.html
@@ -1,22 +1,13 @@
-{% extends "base.html" %}
+{% extends "error_base.html" %}
 
-{% block title %}{{ render_title('Page Not Found') }}{% endblock %}
+{% block title %}Page not found{% endblock %}
 
-{% block content %}
-  <p>We're sorry, but the page you were looking for cannot be found.</p>
+{% block heading %}404: Not found{% endblock %}
 
-  <h2>Most likely causes</h2>
+{% block description %}The link you clicked may be broken or the page may have been removed.{% endblock %}
 
-  <ul>
-    <li>There might be a typing error in the address.</li>
-    <li>If you clicked on a link, it may be out of date.</li>
-  </ul>
-
-  <h2>What you can try</h2>
-
-  <ul>
-    <li>Re-type the address.</li>
-    <li>Go to our <a href="/">homepage</a> and look for the information you want.</li>
-    <li>Contact us, so we can help you find what you are looking for.</li>
-  </ul>
+{% block footer_link %}
+  <a href="/" class="err-Error_FooterLink">
+    Go to our homepage
+  </a>
 {% endblock %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/500.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/500.html
@@ -1,15 +1,15 @@
-{% extends "base.html" %}
+{% extends "error_base.html" %}
 
-{% block title %}{{ render_title('Server Error') }}{% endblock %}
+{% block title %}Server error{% endblock %}
 
-{% block content %}
-  <p>We're sorry, but the site is currently experiencing some technical
-    difficulties. </p>
+{% block heading %}500: Server error{% endblock %}
 
-  <h2>What you can try</h2>
+{% block description %}An unexpected error has occurred.<br>
+  Please try again shortly.
+{% endblock %}
 
-  <ul>
-    <li>Contact us, so we find out about the error as soon as possible.</li>
-    <li>Come back in a few hours and try again.</li>
-  </ul>
+{% block footer_link %}
+  <a href="javascript:location.reload()" class="err-Error_FooterLink">
+    Reload this page
+  </a>
 {% endblock %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/error_base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/error_base.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}{% endblock %}</title>
+
+    <!-- Favicons -->
+    {% include 'base/_favicons.html' %}
+
+    {% compress css %}
+      <link rel="stylesheet" href="{{ static('build/css/app.css') }}">
+    {% endcompress %}
+  </head>
+
+  <body class="err-ErrorBody" style="{% block body_style %}{% endblock %}">
+    <div class="err-Error" style="{% block error_style %}{% endblock %}">
+      <div class="err-Error_Container">
+        <h1 class="err-Error_Heading">{% block heading %}{% endblock %}</h1>
+
+        <p class="err-Error_Description">{% block description %}{% endblock %}</p>
+
+        <p class="err-Error_Footer">
+          {% block footer_link %}
+          {% endblock %}
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/error_base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/error_base.html
@@ -13,7 +13,7 @@
     {% endcompress %}
   </head>
 
-  <body class="err-ErrorBody" style="{% block body_style %}{% endblock %}">
+  <body>
     <div class="err-Error" style="{% block error_style %}{% endblock %}">
       <div class="err-Error_Container">
         <h1 class="err-Error_Heading">{% block heading %}{% endblock %}</h1>


### PR DESCRIPTION
Our current ones are a bit wordy (in my opinion), and a full-layout render on 404 has performance implications (because as far as I know the CMS is still dependent on the 404 route to render pages). This fixes both of these things.

We tend to implement some version of a stripped-down, full-viewport error page on all of our recent sites so maybe this will be a good base for one.