### PR TITLE
Fix multiple load events being added to lazy images.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/main.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/main.js
@@ -22,7 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const lazyImages = document.querySelectorAll('.js-LazyImage')
     const callback = (entries, observer) => {
       Array.from(entries).forEach((entry, index) => {
-        if (entry.isIntersecting) {
+        if (entry.isIntersecting && !entry.target.dataset.activating) {
+          entry.target.dataset.activating = true
           window.setTimeout(() => {
             new LazyImage({ el: entry.target })
             observer.unobserve(entry.target)


### PR DESCRIPTION
Previously it would occasionally happen that more than one load event would be attached to an image if you scrolled to bring something in viewport, out of viewport, and back in viewport at just the speed, which would cause an exception as the `transitionend` event would be fired more than once and the blurred fallback would be removed from the DOM more than once.

This fixes it by ensuring that the lazy image JS is only activated once on any element.