### PR TITLE
Fix obvious bug with parallax JS

### DIFF
--- a/{{cookiecutter.repo_name}}/doc/parallax-js.md
+++ b/{{cookiecutter.repo_name}}/doc/parallax-js.md
@@ -23,7 +23,7 @@ Exactly how the parallaxing behaves can be controlled with `data-*` attributes.
 
 ### data-parallax-y-by
 
-This specifies a slightly-arbitrary vertical parallaxing factor. A smaller number will increase the parallax factor, and a larger number will increase it. You can specify a negative number to reverse the parallax effect.
+This specifies a slightly-arbitrary vertical parallaxing factor. A smaller number will decrease the parallax factor, and a larger number will increase it. You can specify a negative number to reverse the parallax effect.
 
 ```html
 <div class="js-Parallax" data-parallax-y-by="2.5"></div>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/parallax/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/parallax/index.js
@@ -140,7 +140,7 @@ export default function () {
       const item = parallaxElements[i]
       // Do nothing if it is not on screen.
       if (scrollBottom < item.top || currentPos > item.bottom) {
-        return
+        continue
       }
       // How far is the middle of the element from the middle of the
       // screen?


### PR DESCRIPTION
Caused by a reworking of a `forEach` into an old-style `for` loop for speed