### PR TITLE
Add current Git commit hash to CSS.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -408,6 +408,13 @@ WYSIWYG_OPTIONS = {
     'content_css': '/static/build/css/wysiwyg.css'
 }
 
+# Current commit hash, used for cache-busting CSS.
+try:
+    GIT_COMMIT_HASH = os.popen('git rev-parse --short HEAD').read().strip()
+# Catch everything so we don't stop the application starting if there's a problem.
+except:  # pylint: disable=bare-except
+    GIT_COMMIT_HASH = ''
+
 NEWS_APPROVAL_SYSTEM = False
 
 GOOGLE_ANALYTICS = '{{cookiecutter.google_analytics}}'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -59,7 +59,7 @@
     {% endif %}
 
     {% compress css %}
-      <link rel="stylesheet" href="{{ static('build/css/app.css') }}">
+      <link rel="stylesheet" href="{{ static('build/css/app.css') }}?last={{ settings.GIT_COMMIT_HASH }}">
     {% endcompress %}
 
     {% block css %}{% endblock %}


### PR DESCRIPTION
Tested on a few projects and seems to work fine. This avoids stale CSS being served.