### PR TITLE
Tiny and possibly-useful tweak to HasImageAdminMixin.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/admin.py
@@ -79,6 +79,9 @@ class ArticleAdmin(HasImageAdminMixin, PageBaseAdmin, VersionAdmin):
 
         return super(ArticleAdmin, self).formfield_for_choice_field(db_field, request, **kwargs)
 
+    def get_image_reference(self, obj):
+        return obj.card_image or obj.image
+
     def render_categories(self, obj):
         categories = obj.categories.all()
         if not categories:

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/admin.py
@@ -110,9 +110,12 @@ class HasImageAdminMixin(object):
     def get_queryset(self, request):
         return super().get_queryset(request).select_related(self.image_field)
 
+    def get_image_reference(self, obj):
+        return getattr(obj, self.image_field)
+
     def get_image(self, obj):
         """Generates a thumbnail of the image."""
-        image = getattr(obj, self.image_field)
+        image = self.get_image_reference(obj)
         if not image:
             return ''
         try:


### PR DESCRIPTION
This allows subclasses to dynamically change what field is used.

Also puts it Into use on the news admin - it'll prefer showing `card_image` in the article list, falling back to an article's main image.