### PR TITLE
Reset border-radius for  <input> elements.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
@@ -8,7 +8,6 @@
 |
 */
 
-/* Enable panning and pinch zoom gestures, but disable additional non-standard gestures such as double-tap to zoom. Disabling double-tap to zoom removes the need for browsers to delay the generation of click events when the user taps the screen. This is an alias for "pan-x pan-y pinch-zoom" (which, for compatibility, is itself still valid). */
 a,
 area,
 button,
@@ -18,9 +17,21 @@ label,
 select,
 summary,
 textarea {
-  /* stylelint-disable property-no-vendor-prefix */
+  /* Enable panning and pinch zoom gestures, but disable additional
+  non-standard gestures such as double-tap to zoom. Disabling double-tap to
+  zoom removes the need for browsers to delay the generation of click events
+  when the user taps the screen. This is an alias for "pan-x pan-y pinch-zoom"
+  (which, for compatibility, is itself still valid). */
   -ms-touch-action: manipulation;
   touch-action: manipulation;
+}
+
+input,
+select,
+summary,
+textarea {
+  /* Older iOS puts a border radius on inputs by default. */
+  border-radius: 0;
 }
 
 body:not(.util-IsTabbing) button:focus,

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
@@ -28,7 +28,6 @@ textarea {
 
 input,
 select,
-summary,
 textarea {
   /* Older iOS puts a border radius on inputs by default. */
   border-radius: 0;


### PR DESCRIPTION
This is to override older iOS Safaris, which puts a surprise `border-radius` on input elements (see BIPP #5).

Bonus change: tidy up a comment in `define.css`.