### PR TITLE
Remove Safari-specific IFrame hack.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/main.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/main.js
@@ -8,7 +8,7 @@ import { svg4everybody } from './utils/svgforeverybody'
 
 import LazyImage from './images'
 import { Navigation } from './site'
-import { externalLinks, iframeFix } from './utils'
+import { externalLinks } from './utils'
 import { overflowTables } from './wysiwyg'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -38,14 +38,6 @@ document.addEventListener('DOMContentLoaded', () => {
       threshold: 0.4
     })
     Array.from(lazyImages).forEach(image => observer.observe(image))
-  }
-
-  // If the browser isn't Safari, don't do anything
-  if (
-    document.querySelector('iframe') &&
-    window.navigator.userAgent.indexOf('Safari') > -1
-  ) {
-    iframeFix()
   }
 
   // If the device is iOS add a class to the body so we can do specific CSS for it

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/index.js
@@ -89,26 +89,6 @@ export const mediaBreakpoints = {
   xxlg: 1600
 }
 
-/*
- https://github.com/vuejs/vue/issues/4419
-
- As per this, since we mount Vue on the `#app` element this breaks iframes in Safari (Safari bug).
- This snippet removes the iframe and re-inserts it so Safari is happy
- */
-export function iframeFix () {
-  const iframes = document.querySelectorAll('iframe')
-
-  if (iframes.length > 0) {
-    for (const iframe of iframes) {
-      const iframeCopy = iframe.cloneNode()
-      const parent = iframe.parentNode
-
-      parent.insertBefore(iframeCopy, iframe)
-      parent.removeChild(iframe)
-    }
-  }
-}
-
 export function getOffsetTop (el, parent = document.body) {
   let offsetTop = 0
 


### PR DESCRIPTION
This was a work-around for a Vue issue, but as we now mount Vue selectively only where it's needed we don't need this anymore.