### PR TITLE
Add a get_related_items helper function

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_models.py
@@ -80,6 +80,10 @@ class TestNews(TestCase):
         self._create_objects()
         self.assertEqual(self.article.get_absolute_url(), '/foo/')
 
+    def test_article_get_related_articles(self):
+        self._create_objects()
+        self.assertNotEqual(len(self.article.get_related_articles()), 0)
+
     def test_articlemanager_select_published(self):
         self._create_objects()
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/utils.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/utils.py
@@ -1,0 +1,36 @@
+'''Miscellaneous helpful functions.'''
+
+
+def get_related_items(candidate_querysets, count=3, exclude=None):
+    '''
+    Returns `count` related items for an object given one or more candidate
+    querysets. `exclude` should be an object you would like to exclude; for
+    example, if you are trying to get similar news articles for a certain
+    article, you will want to pass the article in question as the `exclude`
+    parameter.
+
+    An example from the news app:
+
+    def get_related_articles(self, count=3):
+        candidate_querysets = [
+            Article.objects.filter(categories__in=self.categories.all()),
+            Article.objects.all(),
+        ]
+        return get_related_items(candidate_querysets, count=count, exclude=self)
+    '''
+    objects = []
+
+    for candidate_queryset in candidate_querysets:
+        if exclude:
+            candidate_queryset = candidate_queryset.exclude(pk=exclude.pk)
+
+        objects += list(
+            candidate_queryset.exclude(
+                pk__in=[obj_existing.pk for obj_existing in objects]
+            ).distinct()[:count - len(objects)]
+        )
+
+        if len(objects) >= count:
+            break
+
+    return objects


### PR DESCRIPTION
This is fairly well-tested at this point (CSP, UK5G, BIPP) and it saves us re-implementing some version of it on every model. It doesn't make any assumptions about what model the related items use (you can easily, say, use it to get related events for a news article). Bonus: it updates `get_related_articles` on the news app.