### PR TITLE
RSS bug fixes.

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -17,6 +17,7 @@ django-suit
 django-watson==1.3.1
 django-webpack-loader
 Jinja2
+lxml
 onespacemedia-cms
 onespacemedia-server-management
 paramiko==1.16.0

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_views.py
@@ -90,9 +90,6 @@ class TestViews(TestCase):
 
         self.assertEqual(get.status_code, 200)
 
-        # Handle single and double digit dates.
-        self.assertIn(get['Content-Length'], ['376', '377'])
-
         self.assertEqual(get['Content-Type'], 'application/rss+xml; charset=utf-8')
 
     def test_articledetailview_get_context_data(self):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_views.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from cms.apps.pages.middleware import RequestPageManager
 from cms.apps.pages.models import Page
 from django.contrib.contenttypes.models import ContentType
@@ -6,6 +7,7 @@ from django.utils.timezone import now
 from django.views import generic
 from watson import search
 
+from ....utils.utils import url_from_path
 from ..models import Article, Category, NewsFeed
 from ..views import ArticleDetailView, ArticleFeedView, ArticleListMixin
 
@@ -43,6 +45,7 @@ class TestViews(TestCase):
                 news_feed=self.feed,
                 title='Foo',
                 slug='foo',
+                content=r'<p>Some links in this article below</p>\r\n<p><a href="/newfeedpage/" title="Valid news feedpage">/newfeedpage/</a></p>\r\n<p><a href="newfeedpage/" title="Invalid news feedpage">newfeedpage</a></p>\r\n<p></p>\r\n<p>iframe below</p>\r\n<p><iframe src="https://www.w3schools.com"></iframe></p>\r\n<p>an_image below</p>\r\n<p><img src="/r/16-2/" alt="events_02" title="events_02" /></p>',
                 date=self.date,
             )
 
@@ -88,8 +91,21 @@ class TestViews(TestCase):
 
         get = view.get(view.request)
 
-        self.assertEqual(get.status_code, 200)
+        content = get.content
+        content = content.decode('utf-8')
+        soup = BeautifulSoup(content, features="xml")
+        links = soup.find_all('link')
+        news_url_link = str(links[0])
+        article_url_link = str(links[1])
 
+        self.assertEqual(get.status_code, 200)
+        self.assertGreater(len(content), len(self.article.content))
+
+        # bs returns None if there is no RSS tag. This behaviour may change in future?
+        self.assertIsNotNone(soup.rss)
+        self.assertIsNone(soup.iframe)
+        self.assertEqual(news_url_link, f'<link>{url_from_path("/")}</link>')
+        self.assertEqual(article_url_link, f'<link>{url_from_path(self.article.slug)}/</link>')
         self.assertEqual(get['Content-Type'], 'application/rss+xml; charset=utf-8')
 
     def test_articledetailview_get_context_data(self):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
@@ -101,7 +101,7 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
                     replacement = '[Embedded media]'
                 element.replace_with(replacement)
 
-            # Add absolute path internal link starting with /.
+            # Add absolute path internal link starting with "/".
             if element.name == 'a' and element.has_attr('href'):
                     element_href_value = element['href']
                     if element_href_value.startswith('/') and not element_href_value.startswith('//'):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
@@ -100,6 +100,12 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
                 else:
                     replacement = '[Embedded media]'
                 element.replace_with(replacement)
+
+            # Add absolute path internal link starting with /.
+            if element.name == 'a' and element.has_attr('href'):
+                    element_href_value = element['href']
+                    if element_href_value.startswith('/') and not element_href_value.startswith('//'):
+                        element['href'] = url_from_path(element_href_value)
         html = str(soup)
 
         return str(html)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
@@ -96,10 +96,13 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
             if element.name == 'iframe':
                 # No src= should not cause an exception.
                 if element.has_attr('src'):
-                    replacement = '<a href="{}">[Embedded media]</a>'.format(element['src'])
+                    element.name = 'a'
+                    element['href'] = element['src']
+                    element.string = '[Embedded media]'
+                    del element['src']
                 else:
                     replacement = '[Embedded media]'
-                element.replace_with(replacement)
+                    element.replace_with(replacement)
 
             # Add absolute path internal link starting with "/".
             if element.name == 'a' and element.has_attr('href'):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
@@ -1,12 +1,14 @@
 """Views used by the CMS news app."""
 
-from cms.html import process as process_html
+from bs4 import BeautifulSoup
+from cms.html import process as cms_process_html
 from cms.views import SearchMetaDetailMixin
 from django.http import HttpResponse
 from django.utils.feedgenerator import DefaultFeed
 from django.views.generic import DetailView, ListView
 from django.views.generic.list import BaseListView
 
+from ...utils.utils import url_from_path
 from .models import Article, Category
 
 
@@ -72,6 +74,36 @@ class ArticleArchiveView(ArticleListMixin, ListView):
 
 
 class ArticleFeedView(ArticleListMixin, BaseListView):
+
+    def process_rss(self, text):
+        """Processes CMS content into RSS format."""
+        html = cms_process_html(text)
+
+        # RSS has certain requirements: iframes are not allowed, image references
+        # must be absolute and style attributes are forbidden.
+        soup = BeautifulSoup(html, 'html.parser')
+        for element in soup.find_all():
+            # Remove inline CSS (common from pasting from Word or Google Docs)
+            if element.has_attr('style'):
+                del element.attrs['style']
+
+            # Make local image references absolute.
+            if element.name == 'img':
+                if element.has_attr('src') and element['src'].startswith('/'):
+                    element['src'] = url_from_path(element['src'])
+
+            # Remove iframe elements.
+            if element.name == 'iframe':
+                # No src= should not cause an exception.
+                if element.has_attr('src'):
+                    replacement = '<a href="{}">[Embedded media]</a>'.format(element['src'])
+                else:
+                    replacement = '[Embedded media]'
+                element.replace_with(replacement)
+        html = str(soup)
+
+        return str(html)
+
     def get(self, request, *args, **kwargs):
         """Generates the RSS feed."""
         page = request.pages.current
@@ -79,7 +111,7 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
         # Write the feed headers.
         feed = DefaultFeed(
             title=page.title,
-            link=page.get_absolute_url(),
+            link=url_from_path(page.get_absolute_url()),
             description=page.meta_description,
         )
 
@@ -87,8 +119,8 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
         for article in self.get_queryset()[:30]:
             feed.add_item(
                 title=article.title,
-                link=article.get_absolute_url(),
-                description=process_html(
+                link=url_from_path(article.get_absolute_url()),
+                description=self.process_rss(
                     article.summary or article.content),
                 pubdate=article.date,
             )
@@ -97,7 +129,6 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
         content = feed.writeString('utf-8')
         response = HttpResponse(content)
         response['Content-Type'] = feed.mime_type
-        response['Content-Length'] = len(content)
 
         return response
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
@@ -103,9 +103,9 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
 
             # Add absolute path internal link starting with "/".
             if element.name == 'a' and element.has_attr('href'):
-                    element_href_value = element['href']
-                    if element_href_value.startswith('/') and not element_href_value.startswith('//'):
-                        element['href'] = url_from_path(element_href_value)
+                element_href_value = element['href']
+                if element_href_value.startswith('/') and not element_href_value.startswith('//'):
+                    element['href'] = url_from_path(element_href_value)
         html = str(soup)
 
         return str(html)
@@ -126,8 +126,7 @@ class ArticleFeedView(ArticleListMixin, BaseListView):
             feed.add_item(
                 title=article.title,
                 link=url_from_path(article.get_absolute_url()),
-                description=self.process_rss(
-                    article.summary or article.content),
+                description=self.process_rss(article.content),
                 pubdate=article.date,
             )
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/tests/test_utils.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/tests/test_utils.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.test import TestCase
+
+from ..utils import url_from_path
+
+
+class UtilsUtilsTest(TestCase):
+
+    def test_url_from_path(self):
+
+        site_url = url_from_path('\\')
+        site_domain = settings.SITE_DOMAIN
+
+        self.assertTrue(site_url.startswith('http'))
+        self.assertIn(site_domain, site_url)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/tests/test_utils.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/tests/test_utils.py
@@ -8,7 +8,7 @@ class UtilsUtilsTest(TestCase):
 
     def test_url_from_path(self):
 
-        site_url = url_from_path('\\')
+        site_url = url_from_path('/')
         site_domain = settings.SITE_DOMAIN
 
         self.assertTrue(site_url.startswith('http'))

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/utils.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/utils.py
@@ -1,5 +1,7 @@
 '''Miscellaneous helpful functions.'''
 
+from django.conf import settings
+
 
 def get_related_items(candidate_querysets, count=3, exclude=None):
     '''
@@ -34,3 +36,18 @@ def get_related_items(candidate_querysets, count=3, exclude=None):
             break
 
     return objects
+
+
+def url_from_path(path, request=None):
+    if path.startswith('http://') or path.startswith('https://'):
+        return path
+
+    if not path.startswith('/'):
+        path = '/' + path
+
+    if request and not request.is_secure():
+        secure_part = ''
+    else:
+        secure_part = 's'
+
+    return 'http{}://{}{}'.format(secure_part, settings.SITE_DOMAIN, path)


### PR DESCRIPTION
Add. process_rss method inside of ArticleFeedView to process cms content correctly for RSS.

url_from_path added to util to help getting correct base url.

URLs in <link> now returns correct absolute url now.

Manually setting content-length removed as it was giving wrong length. Django automatically adds content-length correctly.

Remove test relating to content-length.