### PR TITLE
Change the way <a> elements are reset.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/define.css
@@ -133,11 +133,20 @@ p {
 |--------------------------------------------------------------------------
 | Typography - Anchors
 |--------------------------------------------------------------------------
+| It is more comment that we *don't* want any kind of default styling on
+| <a> elements. We'll unset any browser styling on <a>, then give some
+| defaults for unclassed <a> elements.
 |
 */
 a {
-  font-weight: 500;
+  font-weight: inherit;
   text-decoration: none;
+
+  color: currentColor;
+}
+
+a:not([class]) {
+  font-weight: 500;
 
   color: var(--Color_Anchor);
 }


### PR DESCRIPTION
So here's my thinking here: It is vastly more common that we want to override any default styling of `<a>` elements than it is that we want some kind of common default; they're almost always styled in very different ways depending on context. We end up overriding the colour & font weight far more often than we end up keeping it. For me, and for the projects we work on, no default styling is usually the right thing to do. (This has been tested on Exonate and it worked very well.)

As a convenience, I've kept the old styling _only_ for `<a>` elements with no class. But a question: should we even be doing this? Outside of WYSIWYGs (and we can handle that case if needs be) when do we have unclassed `<a>`s sitting around that need some default, common styling?