### PR TITLE
Add google fonts async way.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,6 +15,7 @@
     "geoip": "no",
     "uses_typekit": "yes",
     "typekit_kit_id": "",
+    "google_fonts_kit_url": "",
     "google_analytics": "",
     "google_analytics_key": "",
     "adobe_creative_sdk_secret": "",

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -465,6 +465,9 @@ SOCIAL_AUTH_PIPELINE = DEFAULT_AUTH_PIPELINE + (
 TYPEKIT_USED = {% if cookiecutter.uses_typekit == 'yes' %}True{% else %}False{% endif %}
 TYPEKIT_KIT_ID = '{{cookiecutter.typekit_kit_id}}'
 
+# Google fonts
+GOOGLE_FONTS_KIT_URL = 'https://fonts.googleapis.com/css?family=Muli:400,600|Source+Sans+Pro:400,700'
+
 SILENCED_SYSTEM_CHECKS = []
 
 THUMBNAIL_QUALITY = 60

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -466,7 +466,7 @@ TYPEKIT_USED = {% if cookiecutter.uses_typekit == 'yes' %}True{% else %}False{% 
 TYPEKIT_KIT_ID = '{{cookiecutter.typekit_kit_id}}'
 
 # Google fonts
-GOOGLE_FONTS_KIT_URL = 'https://fonts.googleapis.com/css?family=Muli:400,600|Source+Sans+Pro:400,700'
+GOOGLE_FONTS_KIT_URL = '{{cookiecutter.google_fonts_kit_url}}'
 
 SILENCED_SYSTEM_CHECKS = []
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -58,6 +58,10 @@
       {% include 'base/_typekit.html' %}
     {% endif %}
 
+    {% if settings.GOOGLE_FONTS_KIT_URL %}
+      {% include 'base/_google-fonts.html' %}
+    {% endif %}
+
     {% compress css %}
       <link rel="stylesheet" href="{{ static('build/css/app.css') }}?last={{ settings.GIT_COMMIT_HASH }}">
     {% endcompress %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_google-fonts.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_google-fonts.html
@@ -1,0 +1,56 @@
+{#
+Asynchronous Google Font loading.
+
+This allows us to use Google Fonts without blocking the initial page render,
+and only causing a FOUT on the first page load. The contents of the Google
+Font CSS will be stored in the browser's localStorage. How this works:
+
+First, we'll check localStorage for the cached font CSS. If we already have it
+cached inject it as an inline <style> tag.
+
+Once we hit DOMContentLoaded (i.e. we've got a mostly-complete page render
+other than JS, we fetch the Google Font kit whether we have it cached or not.
+This will update the localStorage for the next page load.
+
+If we *didn't* have the font kit cached, then we inject the text of the font
+kit (the CSS itself, not a `<link>` reference to it) into the <head>. We
+don't do this if we did already have it cached to prevent an unnecessary
+layout recomputation).
+#}
+<script>
+  (function () {
+    function injectFontCss(text) {
+      var styleElement = document.createElement('style');
+      styleElement.innerHTML = text;
+      document.head.appendChild(styleElement);
+    }
+
+    var cssPath = {{ settings.GOOGLE_FONTS_KIT_URL }};
+    var cacheKey = '_gfont_cache_{{ settings.GIT_COMMIT_HASH }}';
+    var now = Date.now();
+    var cachedVersion = window.localStorage[cacheKey];
+
+    if (cachedVersion) {
+      injectFontCss(cachedVersion);
+    }
+
+    window.addEventListener('DOMContentLoaded', function () {
+      var req = new XMLHttpRequest();
+      req.addEventListener('load', function () {
+        var text = this.responseText;
+        {#
+        Hack to add font-display: swap.
+        https://github.com/google/fonts/issues/358#issuecomment-379328314
+        #}
+        text = text.replace(/}/g, 'font-display: swap }');
+        window.localStorage[cacheKey] = text;
+
+        if (!cachedVersion) {
+          injectFontCss(text);
+        }
+      });
+      req.open('GET', cssPath);
+      req.send();
+    });
+  })();
+</script>


### PR DESCRIPTION
Asynchronous Google Font loading. Also allows google font to be cached and only load if needed.

Loads google fonts only if it's specified in setting.
Check settings/base for "GOOGLE_FONTS_KIT_URL" to add google fonts.
