### PR TITLE
Migrate from news_feed into page

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/admin.py
@@ -29,7 +29,7 @@ class ArticleAdmin(HasImageAdminMixin, PageBaseAdmin, VersionAdmin):
 
     fieldsets = [
         (None, {
-            'fields': ['title', 'slug', 'news_feed', 'featured', 'date', 'status'],
+            'fields': ['title', 'slug', 'page', 'featured', 'date', 'status'],
         }),
         ('Content', {
             'fields': ['image', 'card_image', 'content', 'summary', 'categories'{% if cookiecutter.people == 'yes' %}, 'author'{% endif %}],
@@ -58,7 +58,7 @@ class ArticleAdmin(HasImageAdminMixin, PageBaseAdmin, VersionAdmin):
 
     def get_form(self, request, obj=None, **kwargs):
         form = super(ArticleAdmin, self).get_form(request, obj, **kwargs)
-        form.base_fields['news_feed'].initial = get_default_news_feed()
+        form.base_fields['page'].initial = get_default_news_feed()
         return form
 
     def get_queryset(self, request):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
@@ -108,7 +108,7 @@ class ArticleManager(OnlineBaseManager):
 
         queryset = super(ArticleManager, self).select_published(queryset)
         queryset = queryset.filter(
-            news_feed__page__pk__in=published_news_feed_pages,
+            page__page__pk__in=published_news_feed_pages,
             date__lte=timezone.now().replace(second=0, microsecond=0),
         )
         if getattr(settings, 'NEWS_APPROVAL_SYSTEM', False):
@@ -130,11 +130,12 @@ class Article(PageBase):
 
     objects = ArticleManager()
 
-    news_feed = models.ForeignKey(
+    page = models.ForeignKey(
         'news.NewsFeed',
         on_delete=models.PROTECT,
         null=True,
         blank=False,
+        verbose_name='News feed'
     )
 
     featured = models.BooleanField(
@@ -188,7 +189,7 @@ class Article(PageBase):
     )
 
     class Meta:
-        unique_together = [['news_feed', 'date', 'slug']]
+        unique_together = [['page', 'date', 'slug']]
         ordering = ['-date']
         permissions = [
             ('can_approve_articles', 'Can approve articles'),
@@ -205,7 +206,7 @@ class Article(PageBase):
 
     def get_absolute_url(self):
         """Returns the URL of the article."""
-        return self._get_permalink_for_page(self.news_feed.page)
+        return self._get_permalink_for_page(self.page.page)
 
     def get_related_articles(self, count=3):
         candidate_querysets = [

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
@@ -56,7 +56,7 @@ class TestArticleAdminBase(TestCase):
             )
 
             self.article = Article.objects.create(
-                news_feed=self.feed,
+                page=self.feed,
                 title='Foo',
                 slug='foo',
                 date=self.date,
@@ -96,8 +96,8 @@ class TestArticleAdminBase(TestCase):
     def test_articleadminbase_get_form(self):
         form = self.article_admin.get_form(self.request, obj=None)
         default_feed = get_default_news_feed()
-        self.assertTrue('news_feed' in form.base_fields)
-        self.assertEqual(default_feed, form.base_fields['news_feed'].initial)
+        self.assertTrue('page' in form.base_fields)
+        self.assertEqual(default_feed, form.base_fields['page'].initial)
 
     def test_render_categories(self):
         categories = self.article_admin.render_categories(self.article)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_models.py
@@ -33,7 +33,7 @@ class TestNews(TestCase):
             )
 
             self.article = Article.objects.create(
-                news_feed=self.feed,
+                page=self.feed,
                 title='Foo',
                 slug='foo',
                 # The seconds subtraction is because of time-rounding
@@ -44,14 +44,14 @@ class TestNews(TestCase):
             self.article.categories.add(self.category)
 
             self.article_2 = Article.objects.create(
-                news_feed=self.feed,
+                page=self.feed,
                 title='Foo 2',
                 slug='foo2',
                 date=self.date + timedelta(days=10)
             )
 
             self.article_3 = Article.objects.create(
-                news_feed=self.feed,
+                page=self.feed,
                 title='Foo 3',
                 slug='foo3',
                 status='approved',

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_views.py
@@ -42,7 +42,7 @@ class TestViews(TestCase):
             )
 
             self.article = Article.objects.create(
-                news_feed=self.feed,
+                page=self.feed,
                 title='Foo',
                 slug='foo',
                 content=r'<p>Some links in this article below</p>\r\n<p><a href="/newfeedpage/" title="Valid news feedpage">/newfeedpage/</a></p>\r\n<p><a href="newfeedpage/" title="Invalid news feedpage">newfeedpage</a></p>\r\n<p></p>\r\n<p>iframe below</p>\r\n<p><iframe src="https://www.w3schools.com"></iframe></p>\r\n<p>an_image below</p>\r\n<p><img src="/r/16-2/" alt="events_02" title="events_02" /></p>',

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
@@ -20,7 +20,7 @@ class ArticleMixin(object):
     def get_context_data(self, **kwargs):
         context = super(ArticleMixin, self).get_context_data(**kwargs)
         category_list = Category.objects.filter(
-            article__news_feed__page=self.request.pages.current
+            article__page__page=self.request.pages.current
         ).distinct()
         context['category_list'] = category_list
 
@@ -44,7 +44,7 @@ class ArticleListMixin(ArticleMixin):
             'image',
             'card_image',
         ).filter(
-            news_feed__page=self.request.pages.current,
+            page__page=self.request.pages.current,
         ).order_by(
             '-date'
         )


### PR DESCRIPTION
This is because both careers and events use a page field to specify their default page to be displayed on but articles uses news_feed. This is to bring articles in line with other apps.