### PR TITLE
Migrate the current moderation methods to use the CMS moderation

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/admin.py
@@ -1,6 +1,7 @@
 """Admin settings for the CMS news app."""
 
 from cms.admin import OnlineBaseAdmin, PageBaseAdmin
+from cms.plugins.moderation.models import APPROVED, STATUS_CHOICES
 from django.conf import settings
 from django.contrib import admin
 from reversion.admin import VersionAdmin
@@ -8,7 +9,7 @@ from reversion.models import Version
 from suit.admin import SortableModelAdmin
 
 from ...utils.admin import HasImageAdminMixin
-from .models import STATUS_CHOICES, Article, Category, get_default_news_feed
+from .models import Article, Category, get_default_news_feed
 
 
 @admin.register(Category)
@@ -72,7 +73,7 @@ class ArticleAdmin(HasImageAdminMixin, PageBaseAdmin, VersionAdmin):
         if request:
             choices_list = STATUS_CHOICES
             if getattr(settings, 'NEWS_APPROVAL_SYSTEM', False) and not request.user.has_perm('news.can_approve_articles'):
-                choices_list = [x for x in STATUS_CHOICES if x[0] != 'approved']
+                choices_list = [x for x in STATUS_CHOICES if x[0] != APPROVED]
 
             if db_field.name == 'status':
                 kwargs['choices'] = choices_list

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
@@ -3,6 +3,7 @@ from cms import sitemaps
 from cms.apps.media.models import ImageRefField
 from cms.apps.pages.models import ContentBase, Page
 from cms.models import HtmlField, OnlineBaseManager, PageBase
+from cms.plugins.moderation.models import APPROVED, DRAFT, STATUS_CHOICES
 from cms.templatetags.html import truncate_paragraphs
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -113,16 +114,9 @@ class ArticleManager(OnlineBaseManager):
         )
         if getattr(settings, 'NEWS_APPROVAL_SYSTEM', False):
             queryset = queryset.filter(
-                status='approved'
+                status=APPROVED
             )
         return queryset
-
-
-STATUS_CHOICES = [
-    ('draft', 'Draft'),
-    ('submitted', 'Submitted for approval'),
-    ('approved', 'Approved')
-]
 
 
 class Article(PageBase):
@@ -184,7 +178,7 @@ class Article(PageBase):
     status = models.CharField(
         max_length=100,
         choices=STATUS_CHOICES,
-        default='draft',
+        default=DRAFT,
     )
 
     class Meta:

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
@@ -1,4 +1,5 @@
 from cms.apps.pages.models import Page
+from cms.plugins.moderation.models import APPROVED, DRAFT, STATUS_CHOICES, SUBMITTED
 from django.contrib.admin.sites import AdminSite
 from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TestCase
@@ -68,9 +69,9 @@ class TestArticleAdminBase(TestCase):
     def test_articleadminbase_formfield_for_choice_field(self):
         formfield = self.article_admin.formfield_for_choice_field(self.article._meta.get_field('status'), self.request)
         self.assertListEqual(formfield.choices, [
-            ('draft', 'Draft'),
-            ('submitted', 'Submitted for approval'),
-            ('approved', 'Approved')
+            (DRAFT, 'Draft'),
+            (SUBMITTED, 'Submitted for approval'),
+            (APPROVED, 'Approved')
         ])
 
         self.request.user = MockSuperUser()
@@ -79,9 +80,9 @@ class TestArticleAdminBase(TestCase):
             formfield = self.article_admin.formfield_for_choice_field(self.article._meta.get_field('status'), self.request)
 
         self.assertListEqual(formfield.choices, [
-            ('draft', 'Draft'),
-            ('submitted', 'Submitted for approval'),
-            ('approved', 'Approved')
+            (DRAFT, 'Draft'),
+            (SUBMITTED, 'Submitted for approval'),
+            (APPROVED, 'Approved')
         ])
 
         self.request.user.has_perm = lambda x: False
@@ -89,8 +90,8 @@ class TestArticleAdminBase(TestCase):
             formfield = self.article_admin.formfield_for_choice_field(self.article._meta.get_field('status'), self.request)
 
         self.assertListEqual(formfield.choices, [
-            ('draft', 'Draft'),
-            ('submitted', 'Submitted for approval'),
+            (DRAFT, 'Draft'),
+            (SUBMITTED, 'Submitted for approval'),
         ])
 
     def test_articleadminbase_get_form(self):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
@@ -1,5 +1,6 @@
 from cms.apps.pages.models import Page
-from cms.plugins.moderation.models import APPROVED, DRAFT, STATUS_CHOICES, SUBMITTED
+from cms.plugins.moderation.models import (APPROVED, DRAFT, STATUS_CHOICES,
+                                           SUBMITTED)
 from django.contrib.admin.sites import AdminSite
 from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TestCase

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_models.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from cms.apps.pages.models import Page
 from cms.models import publication_manager
+from cms.plugins.moderation.models import APPROVED
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.utils.timezone import now
@@ -54,7 +55,7 @@ class TestNews(TestCase):
                 news_feed=self.feed,
                 title='Foo 3',
                 slug='foo3',
-                status='approved',
+                status=APPROVED,
                 date=self.date - timedelta(seconds=61),
             )
 


### PR DESCRIPTION
Currently moderation is done via locally defined STATUS_CHOICES and string values. This updates this to use the CMS's moderation models and package.