### PR TITLE
Disable stylelint's selector-max type for <svg>.

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -426,7 +426,12 @@
       "selector-combinator-space-before": "always",
       "selector-descendant-combinator-no-non-space": true,
       "selector-max-id": 0,
-      "selector-max-type": 0,
+      "selector-max-type": [
+        0,
+        {
+          "ignoreTypes": ["svg"]
+        }
+      ],
       "selector-max-universal": 0,
       "selector-no-qualifying-type": true,
       "selector-no-vendor-prefix": true,

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
@@ -92,13 +92,11 @@
   height: 7px;
   margin-left: 10px;
 
-  /* stylelint-disable selector-max-type */
   svg {
     display: block;
     width: inherit;
     height: inherit;
   }
-  /* stylelint-enable */
 }
 
 .nav-Header_LinkIcon-dropdown {


### PR DESCRIPTION
While the special case makes me nervous _per se_ for being a special case, after some discussion this seems like an obvious thing to do.

1) An SVG is always that: an SVG vector graphic. For all other displayed elements that I can think of, their semantic meaning is more often than not completely orthogonal to their visual appearance.
2) Following from that, there is _often_ a good reason to target `<svg>`, because in most cases it's just targeting 'the icon'.
3) It's possible that there is _never_ an illegitimate reason for targeting `<svg>`.