### PR TITLE
Implement section caching

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
@@ -241,6 +241,10 @@ class SectionBase(models.Model):
                 'link_page': 'Please provide either a "Link Page" or a "Link URL"',
             })
 
+    @cached_property
+    def cache_key(self):
+        return f'{self._meta.app_label}.{self._meta.model_name}.{self.pk}'
+
     @property
     def template(self):
         folder_name = self.type.split('-')[0]

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/definitions/property-definitions.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/definitions/property-definitions.css
@@ -68,7 +68,8 @@
   |--------------------------------------------------------------------------
   |
   */
-  font: 16px/1.5 var(--Font_Family-body);
+  font: 16px / 1.5;
+  font-family: var(--Font_Family);
 
   cursor: auto;
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/definitions/property-definitions.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/definitions/property-definitions.css
@@ -68,8 +68,7 @@
   |--------------------------------------------------------------------------
   |
   */
-  font: 16px / 1.5;
-  font-family: var(--Font_Family);
+  font: 16px/1.5 var(--Font_Family-body);
 
   cursor: auto;
 }


### PR DESCRIPTION
Rendering sectioned pages tends to be one of the most expensive operations on a site. Caching sections can result in a substantial speed-up; in real-world testing this can knock a couple of hundred milliseconds or more from TTFB. I think this gives us much of the performance improvements from full-page caching, without any of the traditionally-troublesome edge cases of the latter. This is pretty thoroughly debugged at this point (five projects so far) and has never been a source of trouble.

It will never use the cache if someone is logged in as an admin user. This means that admins will see any changes they make immediately.

If a GET parameter `cache_bypass` is set to some non-empty value, then the cache will not be used, but it *will* be updated with the content of the section. This allows keeping the cache warm on certain important pages (like the homepage) by hitting the URL  every minute with `?cache_bypass=1` tacked on to the end.

The caching is intentionally stupid; it makes no attempt at cache invalidation when a section changes. I don't think this _can_ be done reliably, in principle. This is part of the reason behind the short expiry time.

Extra change: This disables automatic section template creation in `DEBUG` mode, which has been a plentiful source of "works on my machine" and threw `EEXIST` more often than not.