### PR TITLE
Remove `uses_typekit` question from cloning stage.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,7 +13,6 @@
     "news": "yes",
     "sections": "yes",
     "geoip": "no",
-    "uses_typekit": "yes",
     "typekit_kit_id": "",
     "google_fonts_kit_url": "",
     "google_analytics": "",

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -460,7 +460,6 @@ SOCIAL_AUTH_PIPELINE = DEFAULT_AUTH_PIPELINE + (
 )
 
 # Typekit
-TYPEKIT_USED = {% if cookiecutter.uses_typekit == 'yes' %}True{% else %}False{% endif %}
 TYPEKIT_KIT_ID = '{{cookiecutter.typekit_kit_id}}'
 
 # Google fonts

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -54,7 +54,7 @@
     {% block feeds %}{% endblock %}
 
     {# Project #}
-    {% if settings.TYPEKIT_USED %}
+    {% if settings.TYPEKIT_KIT_ID %}
       {% include 'base/_typekit.html' %}
     {% endif %}
 


### PR DESCRIPTION
We already ask for `TYPEKIT_KIT_ID` - it's a truism that if this is non-empty, Typekit is being used.