### PR TITLE
Improve admin lists

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/faqs/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/faqs/admin.py
@@ -1,5 +1,7 @@
 from cms.admin import PageBaseAdmin
 from django.contrib import admin
+from django.core.urlresolvers import reverse
+from django.utils.html import escape, mark_safe
 from suit.admin import SortableModelAdmin
 
 from .models import Category, Faq, Faqs
@@ -7,8 +9,9 @@ from .models import Category, Faq, Faqs
 
 @admin.register(Faq)
 class FaqAdmin(SortableModelAdmin, PageBaseAdmin):
-    list_display = ['__str__', 'category', 'is_online', 'order']
+    list_display = ['__str__', 'render_category', 'is_online', 'order']
     list_editable = ['is_online', 'order']
+    search_fields = ['title', 'page', 'category']
 
     fieldsets = [
         (None, {
@@ -33,6 +36,17 @@ class FaqAdmin(SortableModelAdmin, PageBaseAdmin):
             pass
 
         return form
+
+    def get_queryself(self, request):
+        return super().get_queryset(request).select_related('category')
+
+    def render_category(self, obj):
+        if not obj.category:
+            return '-'
+        url = reverse('admin:faqs_category_change', args=[obj.category.pk])
+        return mark_safe(f'<a href="{url}">{escape(str(obj.category))}</a>')
+    render_category.short_description = 'Category'
+    render_category.admin_order_field = 'category'
 
 
 @admin.register(Category)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/tests/test_admin.py
@@ -103,7 +103,12 @@ class TestArticleAdminBase(TestCase):
 
     def test_render_categories(self):
         categories = self.article_admin.render_categories(self.article)
-        self.assertEqual(categories, 'Foo, Foo 2')
+        self.assertEqual(categories,
+            (
+                '<a href="/admin/news/category/{}/change/">Foo</a>, '
+                '<a href="/admin/news/category/{}/change/">Foo 2</a>'
+            ).format(self.category.pk, self.category_2.pk)
+        )
 
     def test_get_queryset(self):
         # don't do anything with it, just make sure this doesn't throw an

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/admin.py
@@ -48,12 +48,13 @@ class RedirectModelForm(forms.ModelForm):
 
 @admin.register(Redirect)
 class RedirectAdmin(admin.ModelAdmin):
+    list_filter = ['type']
     search_fields = ('old_path', 'new_path')
 
     def get_list_display(self, request):
         if getattr(settings, 'REDIRECTS_ENABLE_REGEX', False):
-            return ('old_path', 'new_path', 'regular_expression', 'test_redirect')
-        return ('old_path', 'new_path', 'test_redirect')
+            return ('old_path', 'new_path', 'regular_expression', 'type', 'test_redirect')
+        return ('old_path', 'new_path', 'type', 'test_redirect')
 
     def get_form(self, request, obj=None, **kwargs):
         kwargs["form"] = RedirectModelForm

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/tests/test_admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/tests/test_admin.py
@@ -37,14 +37,14 @@ class RedirectAdminTestCase(BaseRedirectTestCase):
             self.reset_admin()
             self.assertEqual(
                 self.admin.get_list_display(request),
-                ('old_path', 'new_path', 'test_redirect')
+                ('old_path', 'new_path', 'type', 'test_redirect')
             )
 
         with self.settings(REDIRECTS_ENABLE_REGEX=True):
             self.reset_admin()
             self.assertEqual(
                 self.admin.get_list_display(request),
-                ('old_path', 'new_path', 'regular_expression', 'test_redirect')
+                ('old_path', 'new_path', 'regular_expression', 'type', 'test_redirect')
             )
 
     def test_get_form(self):


### PR DESCRIPTION
* Make foreign keys (and categories M2M for news) in `list_display` linkable to the relevant admin change page
* Make FAQs and people searchable
* Remove 'status' from news `list_filter` if `settings.NEWS_APPROVAL_SYSTEM` is False or unset
* Make redirects filterable by type