### PR TITLE
Rationalise button mixins.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/components/assets/css/components/call-to-action.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/components/assets/css/components/call-to-action.css
@@ -52,7 +52,7 @@
 }
 
 .cta-CallToAction_Link {
-  @include Button-primary;
+  @include Button;
 
   margin-top: 1vr;
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/cookie-consent.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/cookie-consent.css
@@ -70,7 +70,7 @@
 }
 
 .cc-Bar_Accept {
-  @include Button-primary;
+  @include Button;
 
   padding: 4px 15px;
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/mixins/mixins.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/helpers/mixins/mixins.css
@@ -4,7 +4,7 @@
 |--------------------------------------------------------------------------
 |
 */
-@mixin Button {
+@mixin Button-base {
   @include Font_14-20;
 
   display: inline-block;
@@ -20,15 +20,11 @@
     color var(--Global_Transition);
 }
 
-@mixin Button-primary {
-  @include Button;
+@mixin Button {
+  @include Button-base;
 
   background-color: var(--Color_Brand);
   color: #fff;
-}
-
-@mixin Button-secondary {
-  @include Button;
 }
 
 /*

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/error-page.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/modules/error-page.css
@@ -40,5 +40,5 @@
 }
 
 .err-Error_FooterLink {
-  @include Button();
+  @include Button;
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg/wysiwyg.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg/wysiwyg.css
@@ -179,12 +179,8 @@
   |--------------------------------------------------------------------------
   |
   */
-  .wys-Button-primary {
-    @include Button-primary;
-  }
-
-  .wys-Button-secondary {
-    @include Button-secondary;
+  .wys-Button {
+    @include Button;
   }
 
   /*

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -329,19 +329,14 @@ WYSIWYG_OPTIONS = {
     # Custom style formats
     'style_formats': [
         {
-            'title': 'Buttons',
+            'title': 'Links',
             'items': [
                 {
-                    'title': 'Primary',
+                    'title': 'Button',
                     'selector': 'a',
-                    'classes': 'wys-Button-primary'
+                    'classes': 'wys-Button'
                 },
-                {
-                    'title': 'Secondary',
-                    'selector': 'a',
-                    'classes': 'wys-Button-secondary'
-                },
-            ]
+            ],
         },
         {
             'title': 'Titles',


### PR DESCRIPTION
This is to make button names make more sense.

The old `-primary` and `-secondary` sometimes make sense if there are two button styles and there really is some kind of hierarchy rather than just different styles, but a) that is not universally the case, or even the case a majority of the time b) it sets a precedent to end up with `Button-tertiary` and `Button-quaternary`, &c.

Instead, let's not have opinions; make `Button` (previously did only the base styles) into `Button-base`, and make the button style simply `Button`. If we need multiple styles for a project, we'll name additional mixins by appearance, rather than role.