### PR TITLE
Pass focal point info to lazy image so that it doesn't crop out any specified parts.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/templatetags/site.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/templatetags/site.py
@@ -12,6 +12,7 @@ from django.template.defaultfilters import stringfilter
 from django.urls import NoReverseMatch, reverse
 from django.utils.safestring import mark_safe
 from django_jinja import library
+from django_lazy_image.templatetags.lazy_image import lazy_image
 
 from ..models import Footer, Header
 
@@ -268,3 +269,19 @@ def render_pagination(context, page_obj, offset=2, pagination_key=None):
         'paginator': page_obj.paginator,
         'pagination_key': pagination_key or getattr(page_obj, '_pagination_key', 'page')
     }
+
+
+@library.global_function
+@library.render_with('django_lazy_image/lazy-image.html')
+def render_lazy_image(image, height=None, width=None, blur=True, max_width=1920, crop=None, show_small_image=True,
+                      quality=settings.LAZY_IMAGE_DEFAULT_QUALITY_OPTIONS, webp=settings.LAZY_IMAGE_ENABLE_WEBP,
+                      responsive_sizes=None):
+    """
+    Usage: {{ render_lazy_image(path.to.image) }}
+    """
+    # If the image has a focal point set and no crop is set, add the crop
+    if (image.focal_x and image.focal_y) and not crop:
+        focal_x = round(float(image.focal_x))
+        focal_y = round(float(image.focal_y))
+        crop = '{}% {}%'.format(focal_x, focal_y)
+    return lazy_image(image, height, width, blur, max_width, crop, show_small_image, quality, webp, responsive_sizes)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/templatetags/site.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/site/templatetags/site.py
@@ -277,7 +277,7 @@ def render_lazy_image(image, height=None, width=None, blur=True, max_width=1920,
                       quality=settings.LAZY_IMAGE_DEFAULT_QUALITY_OPTIONS, webp=settings.LAZY_IMAGE_ENABLE_WEBP,
                       responsive_sizes=None):
     """
-    Usage: {{ render_lazy_image(path.to.image) }}
+    Usage: render_lazy_image(path.to.image)
     """
     # If the image has a focal point set and no crop is set, add the crop
     if (image.focal_x and image.focal_y) and not crop:

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings/base.py
@@ -286,6 +286,15 @@ SOCIAL_AUTH_PIPELINE = DEFAULT_AUTH_PIPELINE + (
 
 TINYPNG_API_KEY = '{{cookiecutter.tinypng_api_key}}'
 
+LAZY_IMAGE_DEFAULT_QUALITY_OPTIONS = {
+    'normal': 60,
+    'webp': 80,
+}
+LAZY_IMAGE_DEFAULT_QUALITY = LAZY_IMAGE_DEFAULT_QUALITY_OPTIONS['normal']
+LAZY_IMAGE_URL_NAMESPACE = 'assets'
+LAZY_IMAGE_FILE_MODEL = 'media.File'
+LAZY_IMAGE_ENABLE_WEBP = True
+
 TYPEKIT_KIT_ID = '{{cookiecutter.typekit_kit_id}}'
 GOOGLE_FONTS_KIT_URL = '{{cookiecutter.google_fonts_kit_url}}'
 


### PR DESCRIPTION
Relies on [PR for CMS](https://github.com/onespacemedia/cms/pull/154)