### PR TITLE
Remove old cached font kits from localStorage when the commit hash changes

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_google-fonts.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_google-fonts.html
@@ -26,8 +26,16 @@ layout recomputation).
     }
 
     var cssPath = '{{ settings.GOOGLE_FONTS_KIT_URL }}';
-    var cacheKey = '_gfont_cache_{{ settings.GIT_COMMIT_HASH }}';
-    var now = Date.now();
+    var cachePrefix = '_gfont_cache_';
+    var cacheKey = cachePrefix + '{{ settings.GIT_COMMIT_HASH }}';
+    // {# Clear old cache keys. #}
+    var localStorageKeys = Object.keys(window.localStorage)
+    for (var i = 0; i < localStorageKeys.length; i++) {
+      if (localStorageKeys[i].startsWith(cachePrefix) && localStorageKeys[i] !== cacheKey) {
+        window.localStorage.removeItem(localStorageKeys[i])
+      }
+    }
+
     var cachedVersion = window.localStorage[cacheKey];
 
     if (cachedVersion) {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_typekit.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base/_typekit.html
@@ -1,6 +1,19 @@
 <script>
   (function () {
-    var cacheKey = '_tk_cache_{{ settings.GIT_COMMIT_HASH }}';
+    if (!window.localStorage) {
+      return
+    }
+
+    var cachePrefix = '_tk_cache_'
+    var cacheKey = cachePrefix + '{{ settings.GIT_COMMIT_HASH }}';
+    // {# Clear old cache keys. #}
+    var localStorageKeys = Object.keys(window.localStorage)
+    for (var i = 0; i < localStorageKeys.length; i++) {
+      if (localStorageKeys[i].startsWith(cachePrefix) && localStorageKeys[i] !== cacheKey) {
+        window.localStorage.removeItem(localStorageKeys[i])
+      }
+    }
+
     if (window.localStorage && window.localStorage.getItem(cacheKey)) {
       document.documentElement.classList.add('wf-active')
       var script = document.createElement('script')


### PR DESCRIPTION
It's possible, for the font kits accumulated in localStorage to exceed the amount of local storage available. This has only shown itself to be a problem in local development (where we have font kits stored for every commit hash of every project we have worked on). I don't think it's impossible that this could happen during the staging phase of a project, though it's probably a lot less possible that it could happen in production.

This fixes the potential issue by clearing cached font kit localStorage keys for everything except the current commit hash.