### PR TITLE
Add missing wrapElement helper JS.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/index.js
@@ -143,3 +143,39 @@ export function removePreloadClass () {
     body.classList.remove('util-Preload')
   }, 500)
 }
+
+// Wrap an HTMLElement around either a single element, or each element in an
+// HTMLElement array.
+export function wrapElement (toWrap, elms) {
+  // Convert `elms` to an array, if necessary.
+  if (!elms.length) {
+    elms = [elms]
+  } else {
+    /* Array.from allows it to be used on an HTMLCollection. */
+    elms = Array.from(elms)
+  }
+
+  // Loops backwards to prevent having to clone the wrapper on the
+  // first element (see `child` below).
+  for (let i = elms.length - 1; i >= 0; i--) {
+    const child = i > 0 ? toWrap.cloneNode(true) : toWrap
+    const el = elms[i]
+
+    // Cache the current parent and sibling.
+    const parent = el.parentNode
+    const sibling = el.nextSibling
+
+    // Wrap the element (is automatically removed from its current
+    // parent).
+    child.appendChild(el)
+
+    // If the element had a sibling, insert the wrapper before
+    // the sibling to maintain the HTML structure; otherwise, just
+    // append it to the parent.
+    if (sibling) {
+      parent.insertBefore(child, sibling)
+    } else {
+      parent.appendChild(child)
+    }
+  }
+}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/index.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/js/utils/index.js
@@ -146,20 +146,20 @@ export function removePreloadClass () {
 
 // Wrap an HTMLElement around either a single element, or each element in an
 // HTMLElement array.
-export function wrapElement (toWrap, elms) {
-  // Convert `elms` to an array, if necessary.
-  if (!elms.length) {
-    elms = [elms]
+export function wrapElement (toWrap, elements) {
+  // Convert `elements` to an array, if necessary.
+  if (!elements.length) {
+    elements = [elements]
   } else {
     /* Array.from allows it to be used on an HTMLCollection. */
-    elms = Array.from(elms)
+    elements = Array.from(elements)
   }
 
   // Loops backwards to prevent having to clone the wrapper on the
   // first element (see `child` below).
-  for (let i = elms.length - 1; i >= 0; i--) {
+  for (let i = elements.length - 1; i >= 0; i--) {
     const child = i > 0 ? toWrap.cloneNode(true) : toWrap
-    const el = elms[i]
+    const el = elements[i]
 
     // Cache the current parent and sibling.
     const parent = el.parentNode


### PR DESCRIPTION
This is actually [used by the magic WYSIWYG table-wrapping JS](https://github.com/onespacemedia/project-template/blob/develop/%7B%7Bcookiecutter.repo_name%7D%7D/%7B%7Bcookiecutter.package_name%7D%7D/assets/js/wysiwyg/index.js) and this gets added back manually on every project.