### PR TITLE
Allow word breaks inside table elements

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg/wysiwyg.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/wysiwyg/wysiwyg.css
@@ -124,6 +124,7 @@
 
       border-right: 1px solid var(--Color_Border);
       border-bottom: 1px solid var(--Color_Border);
+      overflow-wrap: break-word;
 
       @media (--md) {
         padding: 0.5vr var(--Grid_Gutter);


### PR DESCRIPTION
Table elements often end up having strings that are too long to fit within a cell. This property is similar to `word-break: break-all;` but will only break a word if it has to. Works in all browsers.