### PR TITLE
Add LinkFieldsLastAdminMixin.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/components/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/components/admin.py
@@ -1,14 +1,9 @@
 from django.contrib import admin
 
-{% if cookiecutter.sections == 'yes' %}from ...utils.admin import UsedOnAdminMixin{% endif %}
+from ...utils.admin import LinkFieldsLastAdminMixin{% if cookiecutter.sections == 'yes' %}, UsedOnAdminMixin{% endif %}
 from .models import CallToAction
 
 
 @admin.register(CallToAction)
-class CallToActionAdmin(admin.ModelAdmin{% if cookiecutter.sections == 'yes' %}, UsedOnAdminMixin{% endif %}):
+class CallToActionAdmin(LinkFieldsLastAdminMixin, admin.ModelAdmin{% if cookiecutter.sections == 'yes' %}, UsedOnAdminMixin{% endif %}):
     list_display = ['title'{% if cookiecutter.sections == 'yes' %}, 'pages_used_on'{% endif %}]
-    fieldsets = (
-        (None, {
-            'fields': ['kicker', 'title', 'link_text', 'link_page', 'link_url']
-        }),
-    )

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/admin.py
@@ -2,10 +2,11 @@ from cms.apps.pages.admin import page_admin
 from django.core.urlresolvers import reverse_lazy
 from suit.admin import SortableStackedInline
 
+from ...utils.admin import LinkFieldsLastAdminMixin
 from .models import Content, ContentSection
 
 
-class ContentSectionInline(SortableStackedInline):
+class ContentSectionInline(LinkFieldsLastAdminMixin, SortableStackedInline):
     model = ContentSection
     extra = 0
     filter_horizontal = ['people']

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/admin.py
@@ -14,6 +14,20 @@ except ImportError:
         pass
 
 
+class LinkFieldsLastAdminMixin:
+    '''
+    A mixin for ModelAdmin & its inlines which ensures that fields from
+    HasLinkMixin always come last (which almost invariably makes most sense).
+    '''
+    def get_fields(self, request, obj=None):
+        '''Make fields from HasLinkMixin last.'''
+        fields = list(super().get_fields(request, obj=obj))
+        for field in ['link_page', 'link_url', 'link_text']:
+            fields.remove(field)
+            fields.append(field)
+        return fields
+
+
 class UsedOnAdminMixin(object):
     '''
     Designed for components that are used inside pages.


### PR DESCRIPTION
We have the `HasLinkMixin` abstract model, which is neat, but it has the effect of making anything that inherits from it put its link fields before anything else. This doesn't matter too much on most models (where we almost always define `fieldsets`), but it can be inconvenient on simple models (such as inlines) because `fields` must be defined if you want the link fields to come last (which is almost invariably what we want to happen).

This adds `LinkFieldsLastAdminMixin` which inlines can inherit from to ensure that the fields inherited from `HasLinkMixin` always come after other fields.

(EDITED TO ADD: Currently testing on an active project, let's wait for the content round to be completed before we merge this, IMO.)