### PR TITLE
Fix the admin bar to the bottom of the window rather than the top

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/layout.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/layout.css
@@ -32,7 +32,8 @@
   /* Make way for the edit bar if it's present. */
   .lyt-Body-hasEditBar & {
     @media (--md) {
-      padding-bottom: 40px;
+      /* 24px (typical line height) + 6px + 6px (top and bottom padding) */
+      padding-bottom: 36px;
     }
   }
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/layout.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/base/layout.css
@@ -28,6 +28,13 @@
     overflow: hidden;
   }
   /* stylelint-enable */
+
+  /* Make way for the edit bar if it's present. */
+  .lyt-Body-hasEditBar & {
+    @media (--md) {
+      padding-bottom: 40px;
+    }
+  }
 }
 
 /*

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
@@ -54,6 +54,7 @@
   cursor: pointer;
 
   .svg-Image {
+    width: 15px;
     height: 15px;
     margin-right: calc(var(--Grid_Inside) / 2);
   }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
@@ -11,15 +11,20 @@
 .pg-EditBar {
   display: none;
 
-  padding: 0.25vr var(--Grid_Gutter);
-
-  font-size: 14px;
-
-  background-color: var(--Color_Body);
-  color: #fff;
-
   @media (--md) {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 10;
+
     display: block;
+    padding: 0.25vr var(--Grid_Gutter);
+
+    font-size: 14px;
+
+    background-color: var(--Color_Body);
+    color: #fff;
   }
 }
 
@@ -77,9 +82,9 @@
 */
 .pg-EditBar_FrameContainer {
   position: fixed;
-  top: 36px;
+  top: 0;
   right: 0;
-  bottom: 0;
+  bottom: 36px;
   left: 0;
   z-index: 1000;
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
@@ -19,7 +19,7 @@
     z-index: 10;
 
     display: block;
-    padding: 0.25vr var(--Grid_Gutter);
+    padding: 6px var(--Grid_Gutter);
 
     font-size: 14px;
 
@@ -85,6 +85,8 @@
   position: fixed;
   top: 0;
   right: 0;
+  /* Position the frame so it doesn't overlap the edit bar. This is 24px
+  (typical line height) + 6px + 6px (top and bottom padding) */
   bottom: 36px;
   left: 0;
   z-index: 1000;

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -106,7 +106,7 @@
     {% include 'base/_analytics.html' %}
   </head>
 
-  <body class="util-Preload util-IsTabbing {% block body_class %}{% endblock %}">
+  <body class="util-Preload util-IsTabbing {% if edit_bar() %}lyt-Body-hasEditBar{% endif %} {% block body_class %}{% endblock %}">
     {% include 'base/_browser-update.html' %}
 
     {{ edit_bar() }}


### PR DESCRIPTION
We all seemed to agree that this would be better.

Bonus changes: simplify the CSS - don't set any properties on it at screen widths at which it is `display: none`. Make the SVGs work on IE11 since we officially support it (it needs explicit width and height - it won't fall back to the `viewBox` without them as other browsers will and it'll put it to some arbitrary size).

Tested on at least 2 sites so far, seems to work fine.