### PR TITLE
IE11 fixes for the edit bar

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/static/admin/js/popup_response.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/static/admin/js/popup_response.js
@@ -1,7 +1,5 @@
 /*global opener */
 (function () {
-  'use strict';
-
   if (!opener) opener = window.parent
 
   var initData = JSON.parse(document.getElementById('django-admin-popup-response-constants').dataset.popupResponse);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/edit-bar.css
@@ -49,6 +49,7 @@
   cursor: pointer;
 
   .svg-Image {
+    width: 15px;
     height: 15px;
     margin-right: calc(var(--Grid_Inside) / 2);
   }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/edit_bar.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/edit_bar.html
@@ -45,41 +45,41 @@
   </div>
 
   <script>
-  const editLink = document.querySelector('.js-EditBar_EditLink')
+  (function () {
+    window.dismissChangeRelatedObjectPopup = function () {
+      document.querySelector('.pg-EditBar_FrameContainer').style.opacity = 0
+      window.location.reload()
+    }
 
-  editLink.addEventListener('click', (e) => {
-    e.preventDefault()
+    var editLink = document.querySelector('.js-EditBar_EditLink')
 
-    // Create a containing element
-    const container = document.createElement('div')
-    container.classList.add('pg-EditBar_FrameContainer')
+    editLink.addEventListener('click', function (e) {
+      e.preventDefault()
 
-    // Create an iframe
-    const iframe = document.createElement('iframe')
-    iframe.classList.add('pg-EditBar_Frame')
-    iframe.setAttribute('src', editLink.getAttribute('href'))
+      const container = document.createElement('div')
+      container.classList.add('pg-EditBar_FrameContainer')
 
-    container.appendChild(iframe)
-    document.body.appendChild(container)
+      const iframe = document.createElement('iframe')
+      iframe.classList.add('pg-EditBar_Frame')
+      iframe.setAttribute('src', editLink.getAttribute('href'))
 
-    container.addEventListener('click', (e) => {
-      container.style.opacity = 0
-      document.body.classList.remove('nav-IsOpen')
+      container.appendChild(iframe)
+      document.body.appendChild(container)
 
-      setTimeout(() => {
-        container.remove()
-      }, 150)
+      container.addEventListener('click', function (e) {
+        container.style.opacity = 0
+        document.body.classList.remove('nav-IsOpen')
+
+        setTimeout(function () {
+          container.remove()
+        }, 150)
+      })
+
+      setTimeout(function () {
+        document.body.classList.add('nav-IsOpen')
+        container.style.opacity = 1
+      }, 100)
     })
-
-    setTimeout(() => {
-      document.body.classList.add('nav-IsOpen')
-      container.style.opacity = 1
-    }, 100)
-  })
-
-  function dismissChangeRelatedObjectPopup() {
-    document.querySelector('.pg-EditBar_FrameContainer').style.opacity = 0
-    window.location.reload()
-  }
+  })()
   </script>
 {% endif %}


### PR DESCRIPTION
...since apparently people still use it in locked-down corporate environments and we do officially support it, for now.

Fixes:

1) It no longer uses ES6 syntax that IE11 does not support like fat arrows
2) This removes an errant `use strict` that IE11 (probably correctly) complains about.