### PR TITLE
Accessibility: Make it possible to tab to dropdown menus.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
@@ -202,6 +202,12 @@
     opacity: 1;
     visibility: visible;
   }
+
+  /* See comment under .nav-Header_Dropdown for explanation of code duplication. */
+  .nav-Header_Item-hasDropdown:focus-within > & {
+    opacity: 1;
+    visibility: visible;
+  }
 }
 
 .nav-Header_Link-dropdown {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
@@ -146,7 +146,8 @@
     border-width: 0 6px 6px;
   }
 
-  .nav-Header_Item-hasDropdown:hover > & {
+  .nav-Header_Item-hasDropdown:hover > &,
+  .nav-Header_Item-hasDropdown:focus-within > & {
     opacity: 1;
     visibility: visible;
   }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
@@ -146,6 +146,7 @@
     border-width: 0 6px 6px;
   }
 
+  /* :focus-within allows using the keyboard alone to tab to dropdown menus. */
   .nav-Header_Item-hasDropdown:hover > &,
   .nav-Header_Item-hasDropdown:focus-within > & {
     opacity: 1;

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
@@ -146,8 +146,18 @@
     border-width: 0 6px 6px;
   }
 
-  /* :focus-within allows using the keyboard alone to tab to dropdown menus. */
-  .nav-Header_Item-hasDropdown:hover > &,
+  .nav-Header_Item-hasDropdown:hover > & {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  /*
+  :focus-within allows using the keyboard to tab to dropdown menus. This needs
+  to duplicate the above properties because IE11 and Edge do not support
+  focus-within; if you merge it with the above selector, they will ignore the
+  entire selector (not just the focus-within part) and hover-dropdowns won't
+  work.
+  */
   .nav-Header_Item-hasDropdown:focus-within > & {
     opacity: 1;
     visibility: visible;

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/assets/css/globals/navigation/desktop.css
@@ -154,8 +154,8 @@
   /*
   :focus-within allows using the keyboard to tab to dropdown menus. This needs
   to duplicate the above properties because IE11 and Edge do not support
-  focus-within; if you merge it with the above selector, they will ignore the
-  entire selector (not just the focus-within part) and hover-dropdowns won't
+  focus-within; if you merge it with the above selector, they will ignore
+  both selectors (not just the focus-within one) and hover-dropdowns won't
   work.
   */
   .nav-Header_Item-hasDropdown:focus-within > & {


### PR DESCRIPTION
As titled. As well as showing dropdowns on hover, we can also do them when the element receives focus (via tab completion). While it's actually the link getting focus, there's [this (MDN)](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within):

> The `:focus-within` CSS pseudo-class represents an element that has received focus or contains an element that has received focus.

In testing on a current project, let's see how that goes before merging. (Edit: Tested, works.)