### PR TITLE
[Experimental] Add instant.page.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -164,5 +164,9 @@
 
     {{ render_bundle('vendor', 'js') }}
     {{ render_bundle('app', 'js') }}
+
+    {% if not settings.DEBUG %} {# avoid masking real performance problems in dev #}
+      <script src="https://instant.page/1.2.2" type="module" integrity="sha384-2xV8M5griQmzyiY3CDqh1dn4z3llDVqZDqzjzcY+jCBCk/a5fXJmuZ/40JJAPeoU"></script>
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
Currently on use on our own site. Description from [the project site](https://instant.page/):

> instant.page uses just-in-time preloading — it preloads a page right before a user clicks on it.
>
> Before a user clicks on a link, they hover their mouse over that link. When a user has hovered for 65 ms there is one chance out of two that they will click on that link, so instant.page starts preloading at this moment, leaving on average over 300 ms for the page to preload.
>
> On mobile, a user starts touching their display before releasing it, leaving on average 90 ms to preload the page.

I like it, it really does make jumping between pages feel instant, but there are some concerns and questions:

1) It depends on `GET` never having site effects. This should never be the case, but sometimes is. Hey, what happens if I hover over `/logout/`...yeah, that's something we'll have to be careful about.

2) To what extent will this mask real performance problems? It's not loaded in local dev for this reason, but it makes it uncomfortably easy to ignore this if it's fine in prod. (And divergences between production and local dev always make me nervous. Cf. the above - "why am I randomly logged out every now and then in production but not locally?" :) )

3) Could you actually end up _hurting_ performance under load? 'One chance out of two' also means 'one preload out of two will be a false alarm', which could be another way of saying that one out of every two requests to the server that aren't the users' first page load on the site will be pointless. Server load hasn't historically been an issue for our sites, but what happens when we potentially double it?

4) I'm nervous about loading anything from a CDN as it is currently; `integrity` stops it from being tampered with but I'd probably self-host this in the long run since I can count on `/static/` still existing in four years.

I'm not entirely sure how to feel about all these things yet.