### PR TITLE
Update isort, pylint & friends and consolidate linter configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: Test project
           command: |
             cd demo && . .venv/bin/activate
-            pylint demo/ --load-plugins pylint_django,pylint_mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n
+            pylint demo/ --load-plugins pylint_django,pylint.extensions.mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n
             isort --check-only --diff --quiet --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/*
             yarn run lint:css
             yarn run lint:js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,10 @@ jobs:
           name: Test project
           command: |
             cd demo && . .venv/bin/activate
-            pylint demo/ --load-plugins pylint_django,pylint.extensions.mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n
-            isort --check-only --diff --quiet --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/*
             yarn run lint:css
             yarn run lint:js
+            yarn run lint:python
+            yarn run lint:isort
             pytest --cov=demo --create-db --nomigrations --ds=demo.settings.local
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           name: Install project dependencies
           command: |
             cd demo/ && . .venv/bin/activate
-            pip install --upgrade pytest pytest-cov pytest-django pylint==1.7.5 pylint-django==0.7.2 pylint-mccabe==0.1.3 isort==4.2.15 astroid==1.5.3
+            pip install --upgrade pytest pytest-cov pytest-django
 
       - run:
           name: Test project

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -83,9 +83,6 @@ fi
 pip install --upgrade setuptools
 pip install -r requirements.txt
 
-# Install the linters so the versions get frozen.
-pip install --disable-pip-version-check pylint==1.7.5 pylint-django==0.7.2 pylint-mccabe==0.1.3 isort==4.2.15 astroid==1.5.3
-
 # The requirements will now have versions pinned, so re-dump them.
 pip freeze > requirements.txt
 

--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -30,12 +30,12 @@ jobs:
           name: pylint
           command: |
             . .venv/bin/activate
-            pylint {{ cookiecutter.package_name }}/ --load-plugins pylint_django,pylint.extensions.mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n
+            yarn run lint:python
       - run:
           name: iSort
           command: |
             . .venv/bin/activate
-            isort --check-only --diff --quiet --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/* --skip issue_notify.py
+            yarn run lint:isort
       - run:
           name: tests
           command: |

--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: pylint
           command: |
             . .venv/bin/activate
-            pylint {{ cookiecutter.package_name }}/ --load-plugins pylint_django,pylint_mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n
+            pylint {{ cookiecutter.package_name }}/ --load-plugins pylint_django,pylint.extensions.mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n
       - run:
           name: iSort
           command: |

--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -30,12 +30,12 @@ jobs:
           name: pylint
           command: |
             . .venv/bin/activate
-            yarn run lint:python
+            pylint {{ cookiecutter.package_name }}
       - run:
           name: iSort
           command: |
             . .venv/bin/activate
-            yarn run lint:isort
+            isort --check-only {{ cookiecutter.package_name }}
       - run:
           name: tests
           command: |

--- a/{{cookiecutter.repo_name}}/.isort.cfg
+++ b/{{cookiecutter.repo_name}}/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+skip=issue_notify.py
+skip_glob=.venv,node_modules,*/migrations/*

--- a/{{cookiecutter.repo_name}}/.pylintrc
+++ b/{{cookiecutter.repo_name}}/.pylintrc
@@ -1,11 +1,12 @@
 [MASTER]
-
 profile=no
 ignore=CVS, tests, urls.py, migrations
 persistent=yes
+load-plugins=pylint_django,pylint.extensions.mccabe
+
 
 [MESSAGES CONTROL]
-disable=W0403,W0232,E1101,C0111,R0904,E1002,R0912,C0103,R0801,R0914,C0301,C1001,E1120,E0202,W0613,W0212,W0142
+disable=W0403,W0232,E1101,C0111,R0904,E1002,R0912,C0103,R0801,R0914,C0301,C1001,E1120,E0202,W0613,W0212,W0142,missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code
 
 [REPORTS]
 output-format=text

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -90,7 +90,7 @@
     "build": "gulp production",
     "lint:css": "stylelint \"{{cookiecutter.package_name}}/{assets/**,apps/*/assets/css}/*.css\"",
     "lint:js": "eslint --ext .js,.vue {{cookiecutter.package_name}}/assets/js/{**/*.js,*.js}",
-    "lint:python": "pylint {{cookiecutter.package_name}}/ --load-plugins pylint_django,pylint.extensions.mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n",
+    "lint:python": "pylint {{cookiecutter.package_name}}/",
     "lint:isort": "isort --check-only --diff --quiet --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/* --skip issue_notify.py"
   },
   "lint-staged": {
@@ -111,7 +111,7 @@
       ],
       "**/!(migrations|tests)/*.py": [
         "isort --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/*",
-        "pylint --load-plugins pylint_django,pylint_mccabe -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code,fixme --reports=n",
+        "pylint",
         "git add"
       ]
     }

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -89,7 +89,9 @@
     "dev": "gulp",
     "build": "gulp production",
     "lint:css": "stylelint \"{{cookiecutter.package_name}}/{assets/**,apps/*/assets/css}/*.css\"",
-    "lint:js": "eslint --ext .js,.vue {{cookiecutter.package_name}}/assets/js/{**/*.js,*.js}"
+    "lint:js": "eslint --ext .js,.vue {{cookiecutter.package_name}}/assets/js/{**/*.js,*.js}",
+    "lint:python": "pylint {{cookiecutter.package_name}}/ --load-plugins pylint_django,pylint.extensions.mccabe --ignore=migrations,tests -d missing-docstring,invalid-name,no-init,too-many-ancestors,no-member,line-too-long,attribute-defined-outside-init,too-few-public-methods,no-self-use,unused-argument,protected-access,locally-disabled,duplicate-code --reports=n",
+    "lint:isort": "isort --check-only --diff --quiet --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/* --skip issue_notify.py"
   },
   "lint-staged": {
     "linters": {

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -91,7 +91,7 @@
     "lint:css": "stylelint \"{{cookiecutter.package_name}}/{assets/**,apps/*/assets/css}/*.css\"",
     "lint:js": "eslint --ext .js,.vue {{cookiecutter.package_name}}/assets/js/{**/*.js,*.js}",
     "lint:python": "pylint {{cookiecutter.package_name}}/",
-    "lint:isort": "isort --check-only --diff --quiet --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/* --skip issue_notify.py"
+    "lint:isort": "isort --check-only --diff --quiet"
   },
   "lint-staged": {
     "linters": {
@@ -110,7 +110,7 @@
         "git add"
       ],
       "**/!(migrations|tests)/*.py": [
-        "isort --skip-glob=.venv --skip-glob=node_modules --skip-glob=*/migrations/*",
+        "isort",
         "pylint",
         "git add"
       ]

--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,4 +1,5 @@
 argon2-cffi
+astroid==2.2.5
 beautifulsoup4==4.6.0
 celery[redis]
 CommonMark==0.7.4
@@ -17,6 +18,7 @@ django-suit
 django-watson==1.3.1
 django-webpack-loader
 {% if cookiecutter.emails == 'yes' %}html2text==2018.1.9{% endif %}
+isort==4.3.20
 Jinja2
 lxml
 onespacemedia-cms
@@ -24,6 +26,9 @@ onespacemedia-server-management
 paramiko==1.16.0
 Pillow
 pygithub
+pylint==2.3.0
+pylint-django==2.0.5
+pylint-plugin-utils==0.5
 python-memcached
 rollbar
 social-auth-app-django

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/admin.py
@@ -25,6 +25,8 @@ class CareerOpenClosedListFilter(admin.SimpleListFilter):
         if self.value() == 'open':
             return queryset.select_open()
 
+        return queryset
+
 
 @admin.register(Career)
 class CareerAdmin(SortableModelAdmin, PageBaseAdmin):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/models.py
@@ -93,7 +93,7 @@ class Career(PageBase):
     objects = PageBaseManager.from_queryset(CareerQuerySet)()
 
     page = models.ForeignKey(
-        Careers,
+        'careers.Careers',
         on_delete=models.PROTECT,
     )
 
@@ -104,7 +104,7 @@ class Career(PageBase):
     )
 
     location = models.ForeignKey(
-        CareerLocation,
+        'careers.CareerLocation',
         blank=True,
         null=True,
     )

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/contact/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/contact/views.py
@@ -1,8 +1,8 @@
 from django.views.generic import CreateView, TemplateView
 
 from ..emails.utils import send_email
-from .models import ContactSubmission
 from .forms import ContactForm
+from .models import ContactSubmission
 
 
 class ContactView(CreateView):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/emails/json.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/emails/json.py
@@ -32,30 +32,29 @@ class DjangoJSONEncoder(json.JSONEncoder):
             if r.endswith('+00:00'):
                 r = r[:-6] + 'Z'
             return r
-        elif isinstance(o, datetime.date):
+        if isinstance(o, datetime.date):
             return o.isoformat()
-        elif isinstance(o, datetime.time):
+        if isinstance(o, datetime.time):
             if is_aware(o):
                 raise ValueError("JSON can't represent timezone-aware times.")
             r = o.isoformat()
             if o.microsecond:
                 r = r[:12]
             return r
-        elif isinstance(o, datetime.timedelta):
+        if isinstance(o, datetime.timedelta):
             return duration_iso_string(o)
-        elif isinstance(o, decimal.Decimal):
+        if isinstance(o, decimal.Decimal):
             return str(o)
-        elif isinstance(o, uuid.UUID):
+        if isinstance(o, uuid.UUID):
             return str(o)
-        elif isinstance(o, Promise):
+        if isinstance(o, Promise):
             return six.text_type(o)
-        elif isinstance(o, CallableBool):
+        if isinstance(o, CallableBool):
             return bool(o)
-        elif isinstance(o, Model):
+        if isinstance(o, Model):
             return {
                 'app_label': o._meta.app_label,
                 'model_name': o._meta.model_name,
                 'pk': o.pk,
             }
-        else:
-            return super(DjangoJSONEncoder, self).default(o)
+        return super(DjangoJSONEncoder, self).default(o)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/emails/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/emails/models.py
@@ -86,7 +86,7 @@ class EmailLog(models.Model):
     )
 
     email_template = models.ForeignKey(
-        EmailTemplate,
+        'emails.EmailTemplate',
         on_delete=models.SET_NULL,
         blank=True,
         null=True,

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/emails/templatetags/emails.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/emails/templatetags/emails.py
@@ -1,7 +1,5 @@
 from django import template
-from django_jinja import library
 
-from ...site.templatetags.site import path_to_url
 from ..models import EmailLog, EmailTemplate
 
 register = template.Library()

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/events/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/events/models.py
@@ -76,7 +76,7 @@ class Event(PageBase):
     objects = PageBaseManager.from_queryset(EventQueryset)()
 
     page = models.ForeignKey(
-        Events,
+        'events.Events',
         on_delete=models.PROTECT,
     )
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/faqs/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/faqs/models.py
@@ -52,7 +52,7 @@ class Category(models.Model):
 class Faq(PageBase):
 
     page = models.ForeignKey(
-        Faqs,
+        'faqs.Faqs',
         on_delete=models.PROTECT,
     )
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
@@ -228,6 +228,8 @@ class Article(PageBase):
         if version:
             return version.revision.date_created
 
+        return None
+
     def render_card(self):
         return render_to_string('news/includes/card.html', {
             'object': self,

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/views.py
@@ -12,7 +12,7 @@ from ...utils.utils import url_from_path
 from .models import Article, Category
 
 
-class ArticleMixin(object):
+class ArticleMixin:
     model = Article
 
     context_object_name = 'article'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/models.py
@@ -47,7 +47,7 @@ class People(ContentBase):
 class Person(SearchMetaBase):
 
     page = models.ForeignKey(
-        People,
+        'people.People',
         on_delete=models.PROTECT,
     )
 
@@ -149,6 +149,7 @@ class Person(SearchMetaBase):
     def twitter_url(self):
         if self.twitter:
             return f'https://twitter.com/{self.twitter}'
+        return None
 
     @cached_property
     def colleagues(self):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/admin.py
@@ -43,7 +43,7 @@ class RedirectModelForm(forms.ModelForm):
 
     class Meta:
         model = Redirect
-        exclude = []
+        exclude = []  # pylint:disable=modelform-uses-exclude
 
 
 @admin.register(Redirect)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/middleware.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/redirects/middleware.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from .models import Redirect
 
 
-class RedirectFallbackMiddleware(object):
+class RedirectFallbackMiddleware:
     def _redirect_for_path(self, path):
         if not getattr(settings, "REDIRECTS_ENABLE_REGEX", False):
             try:
@@ -17,7 +17,7 @@ class RedirectFallbackMiddleware(object):
         for redirect in Redirect.objects.all():
             if redirect.old_path == path:
                 return redirect
-            elif redirect.regular_expression and re.match(redirect.old_path, path):
+            if redirect.regular_expression and re.match(redirect.old_path, path):
                 return redirect
 
         return None

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/resources/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/resources/models.py
@@ -85,6 +85,9 @@ class Resources(ContentBase):
         default=12,
     )
 
+    def __str__(self):
+        return self.page.title
+
 
 class ResourceType(models.Model):
     title = models.CharField(
@@ -161,7 +164,7 @@ class Resource(PageBase):
     # |------------------------------------------------------------------------
 
     type = models.ForeignKey(
-        ResourceType,
+        'resources.ResourceType',
         blank=True,
         null=True,
         on_delete=models.SET_NULL,

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/admin.py
@@ -12,7 +12,7 @@ class ContentSectionInline(LinkFieldsLastAdminMixin, SortableStackedInline):
     filter_horizontal = ['people']
     fk_name = 'page'
 
-    class Media(object):
+    class Media:
         js = [reverse_lazy('admin_sections_js')]
 
         css = {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
@@ -312,7 +312,13 @@ class ContentSection(SectionBase):
         on_delete=models.CASCADE,
     )
 
+    def __str__(self):
+        return next((x for x in get_section_types_flat() if x['slug'] == self.type), None)['name']
+
 
 class Content(ContentBase):
 
     icon = 'cms-icons/sections.png'
+
+    def __str__(self):
+        return self.page.title

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/admin.py
@@ -9,10 +9,10 @@ from sorl.thumbnail import get_thumbnail
 try:
     from ..apps.sections.models import ContentSection, SectionBase
 except ImportError:
-    class ContentSection(object):
+    class ContentSection:
         pass
 
-    class SectionBase(object):
+    class SectionBase:
         pass
 
 
@@ -30,7 +30,7 @@ class LinkFieldsLastAdminMixin:
         return fields
 
 
-class UsedOnAdminMixin(object):
+class UsedOnAdminMixin:
     '''
     Designed for components that are used inside pages.
 
@@ -101,7 +101,7 @@ class UsedOnAdminMixin(object):
     pages_used_on.allow_tags = True
 
 
-class HasImageAdminMixin(object):
+class HasImageAdminMixin:
     '''
     A helper to add a thumbnail into admin list views, for models that have an
     ImageRefField field.

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/video.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/utils/video.py
@@ -27,7 +27,7 @@ def get_oembed_info_url(url):
         soup = BeautifulSoup(text, 'html.parser')
     except:  # pylint:disable=bare-except
         # Either requests failed, or it looked nothing like HTML.
-        return
+        return None
 
     # Video providers that support oEmbed will have something that looks like
     # this:
@@ -41,7 +41,7 @@ def get_oembed_info_url(url):
         assert rel_tag.get('href')
     except:  # pylint:disable=bare-except
         # This can probably happen if a video is private or deleted.
-        return
+        return None
 
     # Now, let's grab the JSON
     return rel_tag.get('href')
@@ -60,11 +60,11 @@ def get_video_info(url):
     '''
 
     if not url or (not url.startswith('http://') and not url.startswith('https://')):
-        return
+        return None
 
     oembed_url = get_oembed_info_url(url)
     if not oembed_url:
-        return
+        return None
 
     try:
         req = requests.get(oembed_url)
@@ -74,11 +74,11 @@ def get_video_info(url):
         # happen here. Not just requests.exception.RequestException -
         # there's all the ones that could happen in the json library
         # too.
-        return
+        return None
 
     # Sanity check -
     if not json.get('html'):
-        return
+        return None
 
     return json
 
@@ -88,7 +88,7 @@ def get_video_iframe_url(url, modest=False):
     info = get_video_info(url)
 
     if not info:
-        return
+        return None
 
     soup = BeautifulSoup(info['html'], 'html.parser')
     src = soup.find('iframe')['src']


### PR DESCRIPTION
This bumps isort, pylint and friends to the latest possible versions (there's a bug with pylint-django that precludes using the very latest version). It fixes all errors and warnings that newer versions put out. It also freezes the versions in `requirements.txt`; previously, specific versions were being installed at `cookiecutter`ing time.

This also consolidates the linting configuration. Previously, linter configuration was done by giving isort and pylint command line options in three different places: the project's `.circleci/config.yml`, the project _template's_ `.circleci/config.yml`, and in the `package.json` (for pre-commit hooks). This made it far too easy for project template, project, and pre-commit options to fall out of sync. This consolidates them in two ways:

1) Moving all linting options into `.pylintrc` and `.isort.cfg`. Huge bonus: it'll play nice with whatever editor plugin you might use/want to use. :)
2) Adding package.json scripts (usage: `yarn run lint:python` and `yarn run lint:isort`) that is run in both the project template's CI and the project's CI, to stop those two from falling out of sync too.