### PR TITLE
Make all models that have `get_absolute_url` take an optional `page` argument

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/models.py
@@ -202,8 +202,8 @@ class Career(PageBase):
     def is_open(self):
         return self.closing_date is None or self.closing_date >= now().date()
 
-    def get_absolute_url(self):
-        return self.page.page.reverse('career_detail', kwargs={
+    def get_absolute_url(self, page=None):
+        return (page or self.page.page).reverse('career_detail', kwargs={
             'slug': self.slug,
         })
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/templates/careers/career_list.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/careers/templates/careers/career_list.html
@@ -3,7 +3,7 @@
 {% block main %}
   <ul>
     {% for object in object_list %}
-      <li><a href="{{ object.get_absolute_url() }}">{{ object }}</a></li>
+      <li><a href="{{ object.get_absolute_url(page=pages.current) }}">{{ object }}</a></li>
     {% else %}
       <li>No careers</li>
     {% endfor %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/events/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/events/models.py
@@ -118,8 +118,8 @@ class Event(PageBase):
     def __str__(self):
         return self.title
 
-    def get_absolute_url(self):
-        return self.page.page.reverse('event_detail', kwargs={
+    def get_absolute_url(self, page=None):
+        return (page or self.page.page).reverse('event_detail', kwargs={
             'slug': self.slug,
         })
 
@@ -158,14 +158,16 @@ class Event(PageBase):
 
         return mark_safe(json.dumps(schema))
 
-    def render_card(self):
+    def render_card(self, page=None):
         return render_to_string('events/includes/card.html', {
             'object': self,
+            'page': page,
         })
 
-    def render_featured_card(self):
+    def render_featured_card(self, page=None):
         return render_to_string('events/includes/featured_card.html', {
             'object': self,
+            'page': page,
         })
 
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/events/templates/events/event_list.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/events/templates/events/event_list.html
@@ -3,7 +3,7 @@
 
 {% block main %}
   {% if object_list %}
-    {{ listings.three_up(object_list) }}
+    {{ listings.three_up(object_list, page=pages.current) }}
   {% else %}
     <p>There are no events.</p>
   {% endif %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/faqs/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/faqs/models.py
@@ -86,8 +86,8 @@ class Faq(PageBase):
         verbose_name_plural = 'FAQs'
         ordering = ['order', 'question']
 
-    def get_absolute_url(self):
-        return self.page.page.reverse('faq_detail', kwargs={
+    def get_absolute_url(self, page=None):
+        return (page or self.page.page).reverse('faq_detail', kwargs={
             'slug': self.slug,
         })
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
@@ -205,9 +205,9 @@ class Article(PageBase):
             'slug': self.slug,
         })
 
-    def get_absolute_url(self):
+    def get_absolute_url(self, page=None):
         """Returns the URL of the article."""
-        return self._get_permalink_for_page(self.page.page)
+        return self._get_permalink_for_page(page or self.page.page)
 
     def get_related_articles(self, count=3):
         candidate_querysets = [
@@ -228,14 +228,16 @@ class Article(PageBase):
         if version:
             return version.revision.date_created
 
-    def render_card(self):
+    def render_card(self, page=None):
         return render_to_string('news/includes/card.html', {
             'object': self,
+            'page': page,
         })
 
-    def render_featured_card(self):
+    def render_featured_card(self, page=None):
         return render_to_string('news/includes/featured_card.html', {
             'object': self,
+            'page': page,
         })
 
     @property

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/templates/news/article_list.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/templates/news/article_list.html
@@ -15,7 +15,7 @@
 
 {% block main %}
   {% if object_list %}
-    {{ listings.three_up(object_list) }}
+    {{ listings.three_up(object_list, page=pages.current) }}
   {% else %}
     <p>There are no articles.</p>
   {% endif %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/models.py
@@ -140,8 +140,8 @@ class Person(SearchMetaBase):
 
         return ' '.join(parts)
 
-    def get_absolute_url(self):
-        return self.page.page.reverse('person_detail', kwargs={
+    def get_absolute_url(self, page=None):
+        return (page or self.page.page).reverse('person_detail', kwargs={
             'slug': self.slug,
         })
 
@@ -171,9 +171,10 @@ class Person(SearchMetaBase):
 
         return mark_safe(json.dumps(schema))
 
-    def render_card(self):
+    def render_card(self, page=None):
         return render_to_string('news/includes/card.html', {
             'article': self,
+            'page': page,
         })
 
 historylinks.register(Person)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/templates/people/includes/card.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/templates/people/includes/card.html
@@ -1,4 +1,4 @@
-<a class="ppl-Card" href="{{ object.get_absolute_url() }}">
+<a class="ppl-Card" href="{{ object.get_absolute_url(page=page) }}">
   <div class="ppl-Card_Photo">
     {% if object.card_image or object.photo %}{{ render_lazy_image(object.card_image or object.photo, width=403, height=209) }}{% endif %}
   </div>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/templates/people/person_list.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/people/templates/people/person_list.html
@@ -2,7 +2,7 @@
 
 {% block main %}
   {% if object_list %}
-    {{ listings.four_up(object_list) }}
+    {{ listings.four_up(object_list, page=pages.current) }}
   {% else %}
     <p>There are no people.</p>
   {% endif %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/resources/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/resources/models.py
@@ -183,9 +183,9 @@ class Resource(PageBase):
                 'content': 'Please provide either some page content, an attachment, or an external URL.',
             })
 
-    def get_absolute_url(self):
+    def get_absolute_url(self, page=None):
         if self.content:
-            return self.page.page.reverse('detail', kwargs={
+            return (page or self.page.page).reverse('detail', kwargs={
                 'slug': self.slug,
             })
         if self.file:
@@ -216,14 +216,16 @@ class Resource(PageBase):
                     return extension
         return None
 
-    def render_item(self):
+    def render_item(self, page=None):
         return render_to_string('resources/includes/item.html', {
             'object': self,
+            'page': page,
         })
 
-    def render_featured_item(self):
+    def render_featured_item(self, page=None):
         return render_to_string('resources/includes/featured_item.html', {
             'object': self,
+            'page': page,
         })
 
     def get_related_resources(self, count=3):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/resources/templates/resources/resource_list.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/resources/templates/resources/resource_list.html
@@ -3,7 +3,7 @@
 {% block main %}
   <ul>
     {% for object in object_list %}
-      <li>{{ object.render_item() }}</li>
+      <li>{{ object.render_item(page=pages.current) }}</li>
     {% else %}
       <li>No resources</li>
     {% endfor %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/includes/article_card.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/includes/article_card.html
@@ -1,4 +1,4 @@
-<a class="{% block card_class %}art-Card{% endblock %}" href="{{ object.get_absolute_url() }}">
+<a class="{% block card_class %}art-Card{% endblock %}" href="{{ object.get_absolute_url(page=page) }}">
   {% if object.card_image or object.image %}
     <div class="art-Card_Image">
       {{ render_lazy_image(object.card_image or object.image, width=404, height=218, blur=False, show_small_image=False) }}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/includes/featured_card.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/includes/featured_card.html
@@ -1,4 +1,4 @@
-<a class="art-FeaturedCard" href="{{ object.get_absolute_url() }}">
+<a class="art-FeaturedCard" href="{{ object.get_absolute_url(page=page) }}">
   <div class="art-FeaturedCard_Content">
     {% block content_above %}{% endblock %}
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/macros/listings.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/macros/listings.html
@@ -1,8 +1,8 @@
-{% macro two_up(object_list) %}
+{% macro two_up(object_list, page=None) %}
   <ul class="lst-Grid">
     {% for object in object_list %}
       <li class="lst-Grid_Item lst-Grid_Item-twoUp">
-        {{ object.render_card() }}
+        {{ object.render_card(page=page) }}
       </li>
     {% endfor %}
   </ul>
@@ -12,7 +12,7 @@
   <ul class="lst-Grid">
     {% for object in object_list %}
       <li class="lst-Grid_Item lst-Grid_Item-threeUp">
-        {{ object.render_card() }}
+        {{ object.render_card(page=page) }}
       </li>
     {% endfor %}
   </ul>
@@ -22,7 +22,7 @@
   <ul class="lst-Grid">
     {% for object in object_list %}
       <li class="lst-Grid_Item lst-Grid_Item-fourUp">
-        {{ object.render_card() }}
+        {{ object.render_card(page=page) }}
       </li>
     {% endfor %}
   </ul>
@@ -32,7 +32,7 @@
   <ul class="lst-Stacked">
     {% for object in object_list %}
       <li class="lst-Stacked_Item">
-        {{ object.render_card() }}
+        {{ object.render_card(page=page) }}
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
The standard cliche/template for a model that has a detail page is that they are be FKed to a CMS `ContentBase` derivative, which is FKed to the CMS `Page` model. `get_absolute_url` usually calls `self.page.page.reverse('thingy_detail', kwargs={'slug': self.slug})`.

This causes a performance problem. You can dodge the lookup to its `ContentBase` derivative with `select_related('page')`, but you can't do this for the `ContentBase`'s FK to `Page` (e.g. `page__page`) - it'll be ignored because the publication manager will be used to look up the relation to `Page`. It means that you get at least one database query for every `get_absolute_url` call in listings.

This fixes this problem anywhere it can be fixed by making all models that follow this pattern take an optional `page` argument which the `get_absolute_url` method will prefer to use for the `page.reverse` call. List templates use `{{ object.get_absolute_url(page=pages.current) }}`. In practice, this results in _massive_ speedups whenever there's more than a few objects being listed on a page (try [here](https://www.marshallgroup.co.uk/about/news/) - there are no other performance tricks in use on this page!). I suspect it'll make other things elsewhere on a site faster too; reducing the number of DB queries will probably mean fewer query cache evictions elsewhere.