### PR TITLE
Remove auto-generated summaries for news articles.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
@@ -1,6 +1,5 @@
 """Models used by the CMS news app."""
 import json
-from html import unescape
 
 from cms import sitemaps
 from cms.apps.media.models import ImageRefField

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/models.py
@@ -7,11 +7,9 @@ from cms.apps.media.models import ImageRefField
 from cms.apps.pages.models import ContentBase, Page
 from cms.models import HtmlField, OnlineBaseManager, PageBase
 from cms.plugins.moderation.models import APPROVED, DRAFT, STATUS_CHOICES
-from cms.templatetags.html import truncate_paragraphs
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.template.defaultfilters import striptags, truncatewords
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -215,11 +213,6 @@ class Article(PageBase):
             Article.objects.all(),
         ]
         return get_related_items(candidate_querysets, count=count, exclude=self)
-
-    def get_summary(self, words=20):
-        summary = self.summary or striptags(truncate_paragraphs(self.content, 1))
-
-        return unescape(truncatewords(summary, words))
 
     @property
     def last_modified(self):

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/templates/news/includes/card.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/templates/news/includes/card.html
@@ -1,3 +1,3 @@
 {% extends 'includes/article_card.html' %}
 
-{% block bottom_text %}{% if object.get_summary() %}{{ object.get_summary() }}{% endif %}{% endblock %}
+{% block bottom_text %}{% if object.summary %}{{ object.summary }}{% endif %}{% endblock %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/templates/news/includes/featured_card.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/news/templates/news/includes/featured_card.html
@@ -1,3 +1,3 @@
 {% extends 'includes/featured_card.html' %}
 
-{% block bottom_text %}{% if object.get_summary() %}{{ object.get_summary() }}{% endif %}{% endblock %}
+{% block bottom_text %}{% if object.summary %}{{ object.summary }}{% endif %}{% endblock %}


### PR DESCRIPTION
My opinion is that humans should be writing summaries.

Summaries that are generated from the first N words of the article are a lottery of usefulness; if they give a usable overview of the article it is only by luck. If summaries are required for layout purposes, the summary field should be required. If they are not required for layout purposes, then one does not need to be generated.