### PR TITLE
Update section search code, among other improvements

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
@@ -329,7 +329,7 @@ class ContentSection(SectionBase):
         return self.get_type_display()
 
 
-class SectionedContentBase(ContentBase):
+class SectionedContentBase(ProjectContentBase):
     '''
     A helper ContentBase derivative that ensures that the page's sectioned
     content is indexed by Watson.
@@ -350,6 +350,6 @@ class SectionedContentBase(ContentBase):
         return text
 
 
-class Content(SectionedContentBase, ProjectContentBase):
+class Content(SectionedContentBase):
 
     icon = 'cms-icons/sections.png'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
@@ -258,7 +258,9 @@ class SectionBase(HasLinkMixin, VideoMixin):
 
     @cached_property
     def definition(self):
-        # Let's look for the options for our section type.
+        '''
+        Returns the definition in SECTION_TYPES for this section instance.
+        '''
         for section_group in SECTION_TYPES:
             for section_type in section_group[1]['sections']:
                 section_label = slugify('{}-{}'.format(section_group[0], section_type[0]))

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/apps/sections/models.py
@@ -222,16 +222,15 @@ class SectionBase(HasLinkMixin, VideoMixin):
         return self.get_type_display()
 
     def clean(self):
-        sections = get_section_types_flat()
         required = [getattr(self, field) for field in self.definition.get('required', [])]
 
         if not all(required):
             fields_str = ''
-            fields_len = len(section['required'])
+            fields_len = len(required)
             fields = {}
 
-            for index, field in enumerate(section['required']):
-                fields[field] = ValidationError(f'Please provide an {field}', code='required')
+            for index, field in enumerate(self.definition.get('required', [])):
+                fields[field] = ValidationError(f'This field is required for this section type', code='required')
                 connector = ', '
 
                 if index == fields_len - 2:


### PR DESCRIPTION
This implements the [new](https://github.com/onespacemedia/cms/pull/184) (CMS 4.1.0) `get_searchable_text` method on `ContentBase`. It means that searching for content within sections actually works! It also allows sections to control what text is returned for this; in particular, if anything that it is `ForeignKey`'d to also implements a `get_searchable_text` method, that will be smooshed onto the search blob too.

Bonus changes:
* This implements the `section.definition` cached property - I added it because `self.definition['search']` looked much cleaner. I've replaced the identical loop in the `clean` method.
* Sections no longer re-implement `get_type_display` in their `__str__` method.